### PR TITLE
Update Vue Config with correct backend server var

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/vue3/src/services/AxiosClient.js
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/services/AxiosClient.js
@@ -18,7 +18,7 @@ class ApiService {
   static session
   static init
   constructor() {
-    let base_url = `${window.location.protocol}//${window.location.hostname}/api`
+    let base_url = `${window.location.protocol}//${window.location.host}/api`
 
     console.debug(`API Service for ${base_url}`)
 

--- a/{{cookiecutter.project_slug}}/clients/vue3/vue.config.js
+++ b/{{cookiecutter.project_slug}}/clients/vue3/vue.config.js
@@ -4,7 +4,7 @@ module.exports = {
   devServer: {
     proxy: {
       '/api/': {
-        target: (process.env.DEV_SERVER_BACKEND +'/api/'|| 'https://{{ cookiecutter.project_slug }}-staging.herokuapp.com') + '/api/',
+        target: (process.env.VUE_APP_DEV_SERVER_BACKEND +'/api/'|| 'https://{{ cookiecutter.project_slug }}-staging.herokuapp.com') + '/api/',
         changeOrigin: true,
         pathRewrite: {
           '^/api': '',


### PR DESCRIPTION
Updated `DEV_SERVER_BACKEND` in the vue.config.js to `VUE_APP_DEV_SERVER_BACKEND`. This change matches the variable set in the .env.local example file and follows consistency in [vue](https://cli.vuejs.org/guide/mode-and-env.html#modes) when the app is loaded only `NODE_ENV`, `BASE_URL` and `VUE_APP_*` are exposed in process.env (technically the vue.config.js is exempt from this protection)
