### PR TITLE
added new favicon instructions

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -25,6 +25,7 @@ See the [frontend README](client/README.md)
 
 The Django app is already configured to serve favorite icons for all browsers and platforms (include, for example, apple-icons and android-icons at various sizes). By default, this icon is the vue/react logo.
 
+***Note your image must be a square otherwise a white bg will appear because the file is cropped if it is not a square go to [iloveimg.com](https://www.iloveimg.com/resize-image) and resize it.*** 
 Visit [realfavicongenerator.net](https://realfavicongenerator.net/) and upload a high resolution, square version of the image you would like to use as the favicon for this app.
 
 Download the ZIP file of icons that the site generates for you and paste them in the `client/public/static/favicons/` directory.

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/favicon_urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/favicon_urls.py
@@ -16,14 +16,54 @@ if settings.IN_STAGING or settings.IN_PROD:
             name="favicon",
         ),
         path(
-            r"android-chrome-192x192.png",
-            RedirectView.as_view(url=staticfiles_storage.url("favicons/android-chrome-192x192.png"), permanent=False),
-            name="android-chrome-icon-192",
+            r"apple-icon-57x57.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-57x57.png"), permanent=False),
+            name="apple-icon-57",
         ),
         path(
-            r"android-chrome-512x512.png",
-            RedirectView.as_view(url=staticfiles_storage.url("favicons/android-chrome-512x512.png"), permanent=False),
-            name="android-chrome-icon-512",
+            r"apple-icon-60x60.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-60x60.png"), permanent=False),
+            name="apple-icon-60",
+        ),
+        path(
+            r"apple-icon-72x72.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-72x72.png"), permanent=False),
+            name="apple-icon-72",
+        ),
+        path(
+            r"apple-icon-76x76.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-76x76.png"), permanent=False),
+            name="apple-icon-76",
+        ),
+        path(
+            r"apple-icon-114x114.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-114x114.png"), permanent=False),
+            name="apple-icon-114",
+        ),
+        path(
+            r"apple-icon-120x120.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-120x120.png"), permanent=False),
+            name="apple-icon-120",
+        ),
+        path(
+            r"apple-icon-144x144.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-144x144.png"), permanent=False),
+            name="apple-icon-144",
+        ),
+        path(
+            r"apple-icon-152x152.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-152x152.png"), permanent=False),
+            name="apple-icon-152",
+        ),
+        path(
+            r"apple-icon-180x180.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-icon-180x180.png"), permanent=False),
+            name="apple-icon-180",
+        ),
+        path(
+            r"android-icon-192x192.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/android-icon-192x192.png"), permanent=False),
+            name="apple-icon-192",
         ),
         path(
             r"favicon-32x32.png",
@@ -31,23 +71,23 @@ if settings.IN_STAGING or settings.IN_PROD:
             name="favicon-32",
         ),
         path(
+            r"favicon-96x96.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/favicon-96x96.png"), permanent=False),
+            name="favicon-96",
+        ),
+        path(
             r"favicon-16x16.png",
             RedirectView.as_view(url=staticfiles_storage.url("favicons/favicon-16x16.png"), permanent=False),
             name="favicon-16",
         ),
         path(
-            r"apple-touch-icon.png",
-            RedirectView.as_view(url=staticfiles_storage.url("favicons/apple-touch-icon.png"), permanent=False),
-            name="apple-touch-icon",
+            r"manifest.json",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/manifest.json"), permanent=False),
+            name="icon-manifest",
         ),
         path(
-            r"mstile-150x150.png",
-            RedirectView.as_view(url=staticfiles_storage.url("favicons/mstile-150x150.png"), permanent=False),
-            name="mstile-icon",
-        ),
-        path(
-            r"safari-pinned-tab.svg",
-            RedirectView.as_view(url=staticfiles_storage.url("favicons/safari-pinned-tab.svg"), permanent=False),
-            name="safari-pinned-tab",
+            r"ms-icon-144x144.png",
+            RedirectView.as_view(url=staticfiles_storage.url("favicons/ms-icon-144x144.png"), permanent=False),
+            name="ms-icon",
         ),
     ]


### PR DESCRIPTION
Resolves issue 34 
I re-added the instructions for the favicons with one change, I switched the generator to realfavicongenerator.net this the one we previously used would set a background color instead of leaving it transparent. I also updated the favicon_urls to only serve what is generated based on the new generator. 
