### PR TITLE
Require Rollbar only in Production

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -331,7 +331,7 @@ if not IN_DEV:
 #
 # Rollbar logging config
 #
-if IN_STAGING or IN_PROD:
+if IN_PROD:
     ROLLBAR_ACCESS_TOKEN = config("ROLLBAR_ACCESS_TOKEN")
 else:
     ROLLBAR_ACCESS_TOKEN = config("ROLLBAR_ACCESS_TOKEN")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -331,8 +331,13 @@ if not IN_DEV:
 #
 # Rollbar logging config
 #
+if IN_STAGING or IN_PROD:
+    ROLLBAR_ACCESS_TOKEN = config("ROLLBAR_ACCESS_TOKEN")
+else:
+    ROLLBAR_ACCESS_TOKEN = config("ROLLBAR_ACCESS_TOKEN")
+
 ROLLBAR = {
-    "access_token": config("ROLLBAR_ACCESS_TOKEN"),
+    "access_token": ROLLBAR_ACCESS_TOKEN,
     "environment": ENVIRONMENT,
     "root": BASE_DIR,
 }
@@ -366,7 +371,7 @@ LOGGING = {
         "rollbar": {
             "level": "WARNING",
             "filters": ["require_debug_false"],
-            "access_token": config("ROLLBAR_ACCESS_TOKEN"),
+            "access_token": ROLLBAR_ACCESS_TOKEN,
             "environment": ENVIRONMENT,
             "class": "rollbar.logger.RollbarHandler",
         },

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -373,7 +373,6 @@ if ROLLBAR_ACCESS_TOKEN:
     ROLLBAR = {
         "access_token": ROLLBAR_ACCESS_TOKEN,
         "environment": ENVIRONMENT,
-        "branch": "main",
         "root": BASE_DIR,
     }
     LOGGING["handlers"].update(

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -366,9 +366,9 @@ LOGGING = {
 #
 # Rollbar logging config
 #
-ROLLBAR_ACCESS_TOKEN = _env_get_required("ROLLBAR_ACCESS_TOKEN") if IN_PROD else os.environ.get("ROLLBAR_ACCESS_TOKEN")
+ROLLBAR_ACCESS_TOKEN = config("ROLLBAR_ACCESS_TOKEN", default="")
 
-if ROLLBAR_ACCESS_TOKEN:
+if IN_PROD or ROLLBAR_ACCESS_TOKEN:
     MIDDLEWARE += ["rollbar.contrib.django.middleware.RollbarNotifierMiddleware"]
     ROLLBAR = {
         "access_token": ROLLBAR_ACCESS_TOKEN,


### PR DESCRIPTION
Rollbar is expected for Production.
Right now it errors during initial bootstrap if you don't have a token.