### PR TITLE
Version bumps and config improvements for flake8 and flake8-isort.

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -41,8 +41,8 @@ python_version = "3.9"
 [dev-packages]
 # Code quality
 # ------------------------------------------------------------------------------
-flake8 = "==3.9.2"  # https://github.com/PyCQA/flake8
-flake8-isort = "==4.0.0"  # https://github.com/gforcada/flake8-isort
+flake8 = "==4.0.1"  # https://github.com/PyCQA/flake8
+flake8-isort = "==4.1.1"  # https://github.com/gforcada/flake8-isort
 coverage = "==5.5"  # https://github.com/nedbat/coveragepy
 black = "==21.7b0"  # https://github.com/psf/black
 pylint-django = "==2.4.4"  # https://github.com/PyCQA/pylint-django

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -2,3 +2,11 @@
 line-length = 140
 target-version = ['py39']
 exclude = 'migrations'
+
+[tool.isort]
+py_version = 39
+line_length = 140
+include_trailing_comma = true
+use_parentheses = true
+force_grid_wrap = 0
+multi_line_output = 3


### PR DESCRIPTION
A quick PR to improve the flake8-isort experience, based on my experience on another project.

This PR:
1. Bumps flake8 and flake8-isort to their latest versions. This is not a breaking change AFAIK.
2. Provides a configuration for flake8-isort in pyproject.toml that enables it to play nice with our preferred line length of 140 and `black` auto-formatting. I arrived at this after trial and error and trolling isort GitHub issues. Can affirm that it's working as expected for me.