### PR TITLE
Replace missing GraphQL config

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -31,7 +31,7 @@ drf-nested-routers = "==0.93.3"
 django-anymail = "==8.4"  # https://github.com/anymail/django-anymail
 rollbar = "==0.16.2"
 {%- if cookiecutter.use_graphql == "y" %}
-graphene_django = "==3.0.0b7"
+graphene_django = "==2.15.0"
 django-graphql-jwt = "*"
 {%- endif %}
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
@@ -5,6 +5,16 @@ from rest_framework.authtoken.models import Token
 
 from .models import User
 
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = (
+            "id",
+            "email",
+            "first_name",
+            "last_name",
+            "full_name",
+        )
 
 class UserLoginSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(allow_blank=False, required=True)
@@ -56,15 +66,3 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         return User.objects.create_user(**validated_data)
-
-
-class UserSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = User
-        fields = (
-            "id",
-            "email",
-            "first_name",
-            "last_name",
-            "full_name",
-        )

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.authtoken.models import Token
 
 from .models import User
 
+
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
@@ -15,6 +16,7 @@ class UserSerializer(serializers.ModelSerializer):
             "last_name",
             "full_name",
         )
+
 
 class UserLoginSerializer(serializers.ModelSerializer):
     email = serializers.EmailField(allow_blank=False, required=True)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -17,6 +17,7 @@ from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
 
 from .models import User
 from .permissions import CreateOnlyPermissions
+from .serializers import UserLoginSerializer, UserSerializer
 {% if cookiecutter.use_graphql == 'n' %}from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
 {% endif %}
 {% if cookiecutter.use_graphql == 'y' %}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -17,8 +17,10 @@ from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
 
 from .models import User
 from .permissions import CreateOnlyPermissions
+{% if cookiecutter.use_graphql == 'n' -%}
+from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
+{% else %}
 from .serializers import UserLoginSerializer, UserSerializer
-{% if cookiecutter.use_graphql == 'n' %}from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
 {% endif %}
 {% if cookiecutter.use_graphql == 'y' %}
 # Serve React frontend

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -51,9 +51,9 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
-    {% if cookiecutter.client_app == "React" %}
+    {%- if cookiecutter.client_app == "React" -%}
     "whitenoise.runserver_nostatic",
-    {% endif %}
+    {%- endif %}
     "django.contrib.staticfiles",
     # Third Party
     "corsheaders",
@@ -63,12 +63,12 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_extensions",
-    {% if cookiecutter.use_graphql == 'y' %}
+    {% if cookiecutter.use_graphql == 'y' -%}
     "graphene_django",
-    {% endif %}
+    {%- endif -%}
 ]
 
-{% if cookiecutter.use_graphql == 'y' %}
+{%- if cookiecutter.use_graphql == 'y' -%}
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
     "MIDDLEWARE": [
@@ -86,7 +86,7 @@ AUTHENTICATION_BACKENDS = [
     "graphql_jwt.backends.JSONWebTokenBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
-{% endif %}
+{%- endif %}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -112,7 +112,7 @@ ROOT_URLCONF = "{{ cookiecutter.project_slug }}.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        {% if cookiecutter.client_app != "React" %}
+        {% if cookiecutter.client_app != "React" -%}
         "APP_DIRS": True,
         "DIRS": [
             os.path.join(BASE_DIR, "../client/dist/"),
@@ -122,7 +122,7 @@ TEMPLATES = [
             os.path.join(BASE_DIR, "..", "client", 'build'),
         ],
         "APP_DIRS": True, # this setting must come after "DIRS"!
-        {% endif %}
+        {% endif -%}
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.debug",
@@ -212,13 +212,13 @@ if DEBUG:  # for testing
 #
 # Static files (CSS, JavaScript, Images)
 #
-{% if cookiecutter.client_app != "React" %}
+{% if cookiecutter.client_app != "React" -%}
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 MEDIA_ROOT = os.path.join(BASE_DIR, "media-files")
 {% else %}
 STATIC_ROOT = os.path.join(BASE_DIR, "..", "client", "build")
 MEDIA_ROOT = os.path.join(BASE_DIR, "..", "client", "build", "static")
-{% endif %}
+{% endif -%}
 
 STATIC_URL = "/static/"
 MEDIA_URL = "/media/"
@@ -228,8 +228,8 @@ MEDIA_URL = "/media/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "../client/dist/static"), ]
 {% elif cookiecutter.client_app == 'React' %}
 STATICFILES_DIRS = [os.path.join(STATIC_ROOT, "static"),]
-{% endif %}
-{% endif %}
+{% endif -%}
+{% endif -%}
 
 
 STATICFILES_FINDERS = [
@@ -402,13 +402,13 @@ TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
 CORS_ALLOWED_ORIGINS = [
 {%- if cookiecutter.client_app.lower() != 'none' %}
     "http://localhost:8089",
-{% endif %}
+{% endif -%}
 {% if cookiecutter.use_graphql == 'y' %}
     "http://localhost:3000",
-{% endif %}
+{%- endif %}
     "https://{{ cookiecutter.project_slug }}-staging.herokuapp.com",
     "https://{{ cookiecutter.project_slug }}.herokuapp.com"
 ]
 {% if cookiecutter.use_graphql == 'y' %}
 CORS_ALLOW_CREDENTIALS = True
-{% endif %}
+{% endif -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -51,6 +51,9 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
+    {% if cookiecutter.client_app == "React" %}
+    "whitenoise.runserver_nostatic",
+    {% endif %}
     "django.contrib.staticfiles",
     # Third Party
     "corsheaders",
@@ -60,8 +63,30 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_extensions",
+    {% if cookiecutter.use_graphql == 'y' %}
+    "graphene_django",
+    {% endif %}
 ]
 
+{% if cookiecutter.use_graphql == 'y' %}
+GRAPHENE = {
+    "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
+    "MIDDLEWARE": [
+        "graphql_jwt.middleware.JSONWebTokenMiddleware",
+    ],
+}
+
+GRAPHQL_JWT = {
+    'JWT_VERIFY_EXPIRATION': True,
+    "JWT_EXPIRATION_DELTA": timedelta(minutes=5),
+    "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=7),
+}
+
+AUTHENTICATION_BACKENDS = [
+    "graphql_jwt.backends.JSONWebTokenBackend",
+    "django.contrib.auth.backends.ModelBackend",
+]
+{% endif %}
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
@@ -87,10 +112,17 @@ ROOT_URLCONF = "{{ cookiecutter.project_slug }}.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
+        {% if cookiecutter.client_app != "React" %}
         "APP_DIRS": True,
         "DIRS": [
             os.path.join(BASE_DIR, "../client/dist/"),
         ],
+        {% else %}
+        "DIRS": [
+            os.path.join(BASE_DIR, "..", "client", 'build'),
+        ],
+        "APP_DIRS": True, # this setting must come after "DIRS"!
+        {% endif %}
         "OPTIONS": {
             "context_processors": [
                 "django.template.context_processors.debug",
@@ -180,16 +212,24 @@ if DEBUG:  # for testing
 #
 # Static files (CSS, JavaScript, Images)
 #
-
+{% if cookiecutter.client_app != "React" %}
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 MEDIA_ROOT = os.path.join(BASE_DIR, "media-files")
-
+{% else %}
+STATIC_ROOT = os.path.join(BASE_DIR, "..", "client", "build")
+MEDIA_ROOT = os.path.join(BASE_DIR, "..", "client", "build", "static")
+{% endif %}
 
 STATIC_URL = "/static/"
 MEDIA_URL = "/media/"
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "../client/dist/static"),
-]
+
+{%- if cookiecutter.client_app != 'None' %}
+{%- if cookiecutter.client_app == 'Vue3' %}
+STATICFILES_DIRS = [os.path.join(BASE_DIR, "../client/dist/static"), ]
+{% elif cookiecutter.client_app == 'React' %}
+STATICFILES_DIRS = [os.path.join(STATIC_ROOT, "static"),]
+{% endif %}
+{% endif %}
 
 
 STATICFILES_FINDERS = [
@@ -202,6 +242,7 @@ STATICFILES_FINDERS = [
 # https://anymail.readthedocs.io/en/stable/installation/#installing-anymail
 INSTALLED_APPS += ["anymail"]  # noqa F405
 if not IN_DEV:
+    {%- if cookiecutter.mail_service == 'Mailgun' %}
     # https://anymail.readthedocs.io/en/stable/esps/mailgun/
 
     EMAIL_BACKEND = "anymail.backends.mailgun.EmailBackend"
@@ -210,6 +251,26 @@ if not IN_DEV:
         "MAILGUN_SENDER_DOMAIN": config("MAILGUN_DOMAIN"),
         "MAILGUN_API_URL": config("MAILGUN_API_URL", default="https://api.mailgun.net/v3"),
     }
+    {%- elif cookiecutter.mail_service == 'Amazon SES' %}
+    # https://anymail.readthedocs.io/en/stable/esps/amazon_ses/
+    EMAIL_BACKEND = "anymail.backends.amazon_ses.EmailBackend"
+    ANYMAIL = {}
+    {%- elif cookiecutter.mail_service == 'Custom SMTP' %}
+
+    #
+    # Custom SMTP settings
+    #
+    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+    ANYMAIL = {}
+    EMAIL_HOST = config("SMTP_HOST")
+    EMAIL_PORT = config("SMTP_PORT", default=587, cast=int)
+    EMAIL_HOST_USER = config("SMTP_USER")
+    EMAIL_HOST_PASSWORD = config("SMTP_PASSWORD")
+    EMAIL_ALLOWED_DOMAINS = config("SMTP_VALID_TESTING_DOMAINS")
+    EMAIL_USE_TLS = True
+else:
+    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    {% endif %}
 
 # STORAGES
 # ----------------------------------------------------------------------------
@@ -338,5 +399,16 @@ if IN_PROD or ROLLBAR_ACCESS_TOKEN:
 # Popular testing framework that allows logging to stdout while running unit tests
 TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
 
-CORS_ALLOWED_ORIGINS = ["http://localhost:8089", "https://{{ cookiecutter.project_slug
-}}-staging.herokuapp.com", "https://{{ cookiecutter.project_slug }}.herokuapp.com"]
+CORS_ALLOWED_ORIGINS = [
+{%- if cookiecutter.client_app.lower() != 'none' %}
+    "http://localhost:8089",
+{% endif %}
+{% if cookiecutter.use_graphql == 'y' %}
+    "http://localhost:3000",
+{% endif %}
+    "https://{{ cookiecutter.project_slug }}-staging.herokuapp.com",
+    "https://{{ cookiecutter.project_slug }}.herokuapp.com"
+]
+{% if cookiecutter.use_graphql == 'y' %}
+CORS_ALLOW_CREDENTIALS = True
+{% endif %}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -4,7 +4,7 @@ import dj_database_url
 from decouple import config
 {% if cookiecutter.use_graphql == 'y' -%}
 from datetime import timedelta
-{% endif -%}
+{%- endif %}
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -54,7 +54,7 @@ INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
-    {%- if cookiecutter.client_app == "React" -%}
+    {% if cookiecutter.client_app == "React" -%}
     "whitenoise.runserver_nostatic",
     {%- endif %}
     "django.contrib.staticfiles",
@@ -68,10 +68,10 @@ INSTALLED_APPS = [
     "django_extensions",
     {% if cookiecutter.use_graphql == 'y' -%}
     "graphene_django",
-    {%- endif -%}
+    {%- endif %}
 ]
 
-{%- if cookiecutter.use_graphql == 'y' -%}
+{% if cookiecutter.use_graphql == 'y' -%}
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
     "MIDDLEWARE": [
@@ -80,7 +80,7 @@ GRAPHENE = {
 }
 
 GRAPHQL_JWT = {
-    'JWT_VERIFY_EXPIRATION': True,
+    "JWT_VERIFY_EXPIRATION": True,
     "JWT_EXPIRATION_DELTA": timedelta(minutes=5),
     "JWT_REFRESH_EXPIRATION_DELTA": timedelta(days=7),
 }
@@ -120,11 +120,11 @@ TEMPLATES = [
         "DIRS": [
             os.path.join(BASE_DIR, "../client/dist/"),
         ],
-        {% else %}
+        {% else -%}
         "DIRS": [
-            os.path.join(BASE_DIR, "..", "client", 'build'),
+            os.path.join(BASE_DIR, "..", "client", "build"),
         ],
-        "APP_DIRS": True, # this setting must come after "DIRS"!
+        "APP_DIRS": True,  # this setting must come after "DIRS"!
         {% endif -%}
         "OPTIONS": {
             "context_processors": [
@@ -228,9 +228,13 @@ MEDIA_URL = "/media/"
 
 {%- if cookiecutter.client_app != 'None' %}
 {%- if cookiecutter.client_app == 'Vue3' %}
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "../client/dist/static"), ]
+STATICFILES_DIRS = [
+    os.path.join(BASE_DIR, "../client/dist/static"),
+]
 {% elif cookiecutter.client_app == 'React' %}
-STATICFILES_DIRS = [os.path.join(STATIC_ROOT, "static"),]
+STATICFILES_DIRS = [
+    os.path.join(STATIC_ROOT, "static"),
+]
 {% endif -%}
 {% endif -%}
 
@@ -272,7 +276,7 @@ if not IN_DEV:
     EMAIL_ALLOWED_DOMAINS = config("SMTP_VALID_TESTING_DOMAINS")
     EMAIL_USE_TLS = True
 else:
-    EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+    EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
     {% endif %}
 
 # STORAGES
@@ -402,16 +406,14 @@ if IN_PROD or ROLLBAR_ACCESS_TOKEN:
 # Popular testing framework that allows logging to stdout while running unit tests
 TEST_RUNNER = "django_nose.NoseTestSuiteRunner"
 
-CORS_ALLOWED_ORIGINS = [
-{%- if cookiecutter.client_app.lower() != 'none' %}
-    "http://localhost:8089",
+CORS_ALLOWED_ORIGINS = ["https://{{ cookiecutter.project_slug }}-staging.herokuapp.com", "https://{{ cookiecutter.project_slug }}.herokuapp.com"]
+{% if cookiecutter.client_app.lower() != 'none' -%}
+CORS_ALLOWED_ORIGINS.append("http://localhost:8089")
 {% endif -%}
-{% if cookiecutter.use_graphql == 'y' %}
-    "http://localhost:3000",
-{%- endif %}
-    "https://{{ cookiecutter.project_slug }}-staging.herokuapp.com",
-    "https://{{ cookiecutter.project_slug }}.herokuapp.com"
-]
+{% if cookiecutter.use_graphql == 'y' -%}
+CORS_ALLOWED_ORIGINS.append("http://localhost:3000")
+{%- endif -%}
+
 {% if cookiecutter.use_graphql == 'y' %}
 CORS_ALLOW_CREDENTIALS = True
 {% endif -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -2,6 +2,9 @@ import os
 
 import dj_database_url
 from decouple import config
+{% if cookiecutter.use_graphql == 'y' -%}
+from datetime import timedelta
+{% endif -%}
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -1,10 +1,9 @@
 import os
-
-import dj_database_url
-from decouple import config
 {% if cookiecutter.use_graphql == 'y' -%}
 from datetime import timedelta
-{%- endif -%}
+{%- endif %}
+import dj_database_url
+from decouple import config
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -4,7 +4,7 @@ import dj_database_url
 from decouple import config
 {% if cookiecutter.use_graphql == 'y' -%}
 from datetime import timedelta
-{%- endif %}
+{%- endif -%}
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -56,7 +56,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     {% if cookiecutter.client_app == "React" -%}
     "whitenoise.runserver_nostatic",
-    {%- endif %}
+    {%- endif -%}
     "django.contrib.staticfiles",
     # Third Party
     "corsheaders",
@@ -66,12 +66,12 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_extensions",
-    {% if cookiecutter.use_graphql == 'y' -%}
+    {%- if cookiecutter.use_graphql == 'y' -%}
     "graphene_django",
     {%- endif %}
 ]
 
-{% if cookiecutter.use_graphql == 'y' -%}
+{%- if cookiecutter.use_graphql == 'y' -%}
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
     "MIDDLEWARE": [

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -1,7 +1,15 @@
 from django.contrib import admin
 from django.urls import include, path
+{% if cookiecutter.use_graphql == 'y' %}
+from django.conf import settings
+from django.views.decorators.csrf import csrf_exempt
+from graphene_django.views import GraphQLView
+{% endif %}
 
 urlpatterns = [
+    {% if cookiecutter.use_graphql == 'y' %}
+    path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
+    {% endif %}
     path(r"staff/", admin.site.urls),
     path(r"", include("{{ cookiecutter.project_slug }}.core.favicon_urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.core.urls")),

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -4,7 +4,7 @@ from django.urls import include, path
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
-{% endif %}
+{% endif -%}
 
 urlpatterns = [
     {% if cookiecutter.use_graphql == 'y' -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -4,8 +4,7 @@ from django.urls import include, path
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
-{% endif -%}
-
+{%- endif %}
 urlpatterns = [
     {% if cookiecutter.use_graphql == 'y' -%}
     path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 from django.urls import include, path
-{%- if cookiecutter.use_graphql == 'y' -%}
+{% if cookiecutter.use_graphql == 'y' -%}
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -1,15 +1,15 @@
 from django.contrib import admin
 from django.urls import include, path
-{% if cookiecutter.use_graphql == 'y' %}
+{%- if cookiecutter.use_graphql == 'y' -%}
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
 {% endif %}
 
 urlpatterns = [
-    {% if cookiecutter.use_graphql == 'y' %}
+    {% if cookiecutter.use_graphql == 'y' -%}
     path("graphql", csrf_exempt(GraphQLView.as_view(graphiql=settings.DEBUG))),
-    {% endif %}
+    {% endif -%}
     path(r"staff/", admin.site.urls),
     path(r"", include("{{ cookiecutter.project_slug }}.core.favicon_urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.core.urls")),

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -4,7 +4,7 @@ from django.urls import include, path
 from django.conf import settings
 from django.views.decorators.csrf import csrf_exempt
 from graphene_django.views import GraphQLView
-{% endif -%}
+{% endif %}
 
 urlpatterns = [
     {% if cookiecutter.use_graphql == 'y' -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/utils/emails.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/utils/emails.py
@@ -36,9 +36,7 @@ def send_html_email(subject, template, send_from, send_to, context={}, bcc_email
     #         if domain not in valid_domains:
     #             return
 
-    assert isinstance(
-        send_to, (list, tuple, str)
-    ), "send_to must be an instance of list, tuple, or str"
+    assert isinstance(send_to, (list, tuple, str)), "send_to must be an instance of list, tuple, or str"
 
     if isinstance(send_to, str):
         send_to = [send_to]


### PR DESCRIPTION
## What this does

Adds back missing settings preventing GraphQL from functioning properly in a generated app.

## Checklist
- [x] Replace settings.py options
- [x] Replace urls.py options
- [x] Test on generated app


## Deploy Notes

N/a

## How to test

1. Generate a new app
2. Set up GraphQL server with basic types
3. Go to `localhost:8000/graphql` and verify that GraphiQL interface loads and returns data from server