### PR TITLE
Graphql generating settings.py formatting bugs

### DIFF
--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -114,6 +114,49 @@ USE_AWS_STORAGE='False'
 #     AWS_LOCATION               Folder location inside of the S3 storage bucket.
 #	  AWS_S3_REGION_NAME		 Region name (ex: 'us-east-2') required in order to receive correct
 #								 query authorization mechanism parameters for private URLs.
+#      ** Due to some recent changes in aws these settings must also be made:
+#       1. create the s3 bucket
+#        2. Uncheck disable Block all public access
+#        3. Add this ACL under Bucket Policy (make sure to specify the path of the folder to allow django access so that private is still private) - Permissions
+#            ```
+#
+#            {
+#                "Version": "2012-10-17",
+#                "Statement": [
+#                    {
+#                        "Sid": "PublicReadGetObject",
+#                        "Effect": "Allow",
+#                        "Principal": "*",
+#                        "Action": "s3:GetObject",
+#                        "Resource": "arn:aws:s3:::<bucket-name>/<folder>/static/*"
+#                    }
+#                ]
+#            }
+#            ```
+#            and in CORS - Permissions
+#            ```
+#                [
+#                    {
+#                        "AllowedHeaders": [
+#                            "Authorization"
+#                        ],
+#                        "AllowedMethods": [
+#                            "GET"
+#                        ],
+#                        "AllowedOrigins": [
+#                            "*"
+#                        ],
+#                        "ExposeHeaders": [
+#                            "x-amz-server-side-encryption",
+#                            "x-amz-request-id",
+#                            "x-amz-id-2"
+#                        ],
+#                        "MaxAgeSeconds": 3000
+#                    }
+#                ]
+#            ```
+#
+#
 #
 AWS_ACCESS_KEY_ID=''
 AWS_SECRET_ACCESS_KEY=''

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/admin.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/admin.py
@@ -1,5 +1,54 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin
 
 from .models import User
 
-admin.site.register(User)
+
+class CustomUserAdmin(UserAdmin):
+    model = User
+
+    fieldsets = (
+        (
+            None,
+            {
+                "fields": (
+                    "email",
+                    "first_name",
+                    "last_name",
+                    "password",
+                    "last_login",
+                    "is_staff",
+                )
+            },
+        ),
+    )
+
+    add_fieldsets = (
+        (
+            None,
+            {
+                "classes": ("wide",),
+                "fields": ("email", "password1", "password2"),
+            },
+        ),
+    )
+
+    list_display = ("is_active", "email", "first_name", "last_name")
+
+    list_display_links = (
+        "is_active",
+        "email",
+        "first_name",
+        "last_name",
+    )
+
+    search_fields = (
+        "email",
+        "first_name",
+        "last_name",
+    )
+
+    ordering = []
+
+
+admin.site.register(User, CustomUserAdmin)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/handlers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/handlers.py
@@ -1,9 +1,0 @@
-from django.conf import settings
-from storages.backends.s3boto3 import S3Boto3Storage
-
-
-class PrivateMediaStorage(S3Boto3Storage):
-    location = settings.PRIVATE_MEDIAFILES_LOCATION
-    default_acl = "private"
-    file_overwrite = False
-    custom_domain = False

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/templates/core/index-placeholder.html
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/templates/core/index-placeholder.html
@@ -8,8 +8,23 @@
   <title>{{ cookiecutter.project_name }} &middot; Down for Maintenance</title>
 </head>
 
-<body>
-  <h1>This site is currently offline for maintenance.</h1>
-</body>
+
+  <body>
+    <div style='display:flex; flex-direction:column;justify-content:center;align-items:center;'>
+      <h1> Hi, Welcome to the Django Portal </h1>
+      You are seeing this page for one of two reasons
+      <ul>
+      <li>You have not built your client side </li>
+      <li>Or you have built your client side and haven't collected your static files</li>
+      <ul>
+      <i><strong>To fix this run:</strong> </i>
+      <ul>
+      <li><code> npm run build || yarn run build </code> </li>
+      <li> <code> python server/manage.py collectstatic --no-input</code> </li>
+
+      </ul>
+      </div>
+  </body>
+
 
 </html>

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -30,7 +30,7 @@ from .serializers import UserLoginSerializer, UserSerializer
 @never_cache
 def index(request):
     try:
-        index_path=os.path.join(settings.BASE_DIR.replace('server','client'),'dist/index.html')
+        index_path = os.path.join(settings.BASE_DIR.replace('server', 'client'), 'dist/index.html')
         if not os.path.exists(index_path):
             raise FileNotFoundError
         return TemplateResponse(request, "index.html")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -14,7 +14,6 @@ from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-
 from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
 
 from .models import User
@@ -36,6 +35,7 @@ def index(request):
         return TemplateResponse(request, "index.html")
     except FileNotFoundError:
         return TemplateResponse(request, "core/index-placeholder.html")
+
 
 class UserLoginView(generics.GenericAPIView):
     serializer_class = UserLoginSerializer

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -1,11 +1,9 @@
 import os
+
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
-from django.shortcuts import render
-from django.http import HttpResponse
-from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
@@ -14,6 +12,7 @@ from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
+
 from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
 
 from .models import User

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -37,9 +37,6 @@ def index(request):
     except FileNotFoundError:
         return TemplateResponse(request, "core/index-placeholder.html")
 
-
-
-
 class UserLoginView(generics.GenericAPIView):
     serializer_class = UserLoginSerializer
     authentication_classes = ()

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -30,7 +30,7 @@ from .serializers import UserLoginSerializer, UserSerializer
 @never_cache
 def index(request):
     try:
-        index_path=os.path.join(settings.STATIC_ROOT,'index.html')
+        index_path=os.path.join(settings.BASE_DIR.replace('server','client'),'dist/index.html')
         if not os.path.exists(index_path):
             raise FileNotFoundError
         return TemplateResponse(request, "index.html")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -1,14 +1,16 @@
+import os
 from django.conf import settings
 from django.contrib.auth import authenticate
 from django.contrib.auth.tokens import default_token_generator
 from django.db import transaction
 from django.shortcuts import render
+from django.http import HttpResponse
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
-{% if cookiecutter.use_graphql == 'y' %}from django.template.response import TemplateResponse
+from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import ensure_csrf_cookie
-{% endif %}from rest_framework import generics, mixins, permissions, status, viewsets
+from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
@@ -22,22 +24,21 @@ from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSe
 {% else %}
 from .serializers import UserLoginSerializer, UserSerializer
 {% endif %}
-{% if cookiecutter.use_graphql == 'y' %}
+
 # Serve React frontend
 @ensure_csrf_cookie
 @never_cache
 def index(request):
-    return TemplateResponse(request, "index.html")
-{% elif cookiecutter.client_app.lower() == 'None' %}
-def index(request):
-    return redirect(to="/docs/swagger/")
-{% else %}
-def index(request):
     try:
-        return render(request, "index.html")
-    except TemplateDoesNotExist:
-        return render(request, "core/index-placeholder.html")
-{% endif %}
+        index_path=os.path.join(settings.STATIC_ROOT,'index.html')
+        if not os.path.exists(index_path):
+            raise FileNotFoundError
+        return TemplateResponse(request, "index.html")
+    except FileNotFoundError:
+        return TemplateResponse(request, "core/index-placeholder.html")
+
+
+
 
 class UserLoginView(generics.GenericAPIView):
     serializer_class = UserLoginSerializer

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -27,13 +27,11 @@ from .serializers import UserLoginSerializer, UserSerializer
 @ensure_csrf_cookie
 @never_cache
 def index(request):
-    try:
-        index_path = os.path.join(settings.BASE_DIR.replace('server', 'client'), 'dist/index.html')
-        if not os.path.exists(index_path):
-            raise FileNotFoundError
-        return TemplateResponse(request, "index.html")
-    except FileNotFoundError:
+
+    index_path = os.path.join(settings.BASE_DIR.replace('server', 'client'), 'dist/index.html')
+    if not os.path.exists(index_path):
         return TemplateResponse(request, "core/index-placeholder.html")
+    return TemplateResponse(request, "index.html")
 
 
 class UserLoginView(generics.GenericAPIView):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -65,12 +65,12 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_extensions",
-    {%- if cookiecutter.use_graphql == 'y' -%}
+    {% if cookiecutter.use_graphql == 'y' -%}
     "graphene_django",
     {%- endif %}
 ]
 
-{%- if cookiecutter.use_graphql == 'y' -%}
+{% if cookiecutter.use_graphql == 'y' -%}
 
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
@@ -298,10 +298,9 @@ if config("USE_AWS_STORAGE", cast=bool, default=False):
     AWS_LOCATION = config("AWS_LOCATION", default="")
     AWS_S3_REGION_NAME = config("AWS_S3_REGION_NAME")
 
-    aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
     # Default file storage is private
     PRIVATE_MEDIAFILES_LOCATION = AWS_LOCATION + "/media"
-    STATIC_FILES_LOCATION = AWS_LOCATION + "/media"
+    STATIC_FILES_LOCATION = AWS_LOCATION + "/static"
     DEFAULT_FILE_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.PrivateMediaStorage"
     STATICFILES_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.StaticRootS3Boto3Storage"
     COLLECTFAST_STRATEGY = "collectfast.strategies.boto3.Boto3Strategy"

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -71,6 +71,7 @@ INSTALLED_APPS = [
 ]
 
 {%- if cookiecutter.use_graphql == 'y' -%}
+
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
     "MIDDLEWARE": [

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -281,6 +281,13 @@ else:
 
 # STORAGES
 # ----------------------------------------------------------------------------
+#
+
+# STATIC
+# ------------------------
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+
 
 PRIVATE_MEDIAFILES_LOCATION = ""
 # Django Storages configuration
@@ -295,16 +302,14 @@ if config("USE_AWS_STORAGE", cast=bool, default=False):
     aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
     # Default file storage is private
     PRIVATE_MEDIAFILES_LOCATION = AWS_LOCATION + "/media"
+    STATIC_FILES_LOCATION = AWS_LOCATION + "/media"
     DEFAULT_FILE_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.PrivateMediaStorage"
     STATICFILES_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.StaticRootS3Boto3Storage"
     COLLECTFAST_STRATEGY = "collectfast.strategies.boto3.Boto3Strategy"
-    STATIC_URL = f"https://{aws_s3_domain}/static/"
-    MEDIA_URL = f"https://{aws_s3_domain}/media/"
 
-#
-# STATIC
-# ------------------------
-STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+    STATIC_URL = f"https://{aws_s3_domain}/{STATIC_FILES_LOCATION}/"
+    MEDIA_URL = f"https://{aws_s3_domain}/{PRIVATE_MEDIAFILES_LOCATION}/"
+
 
 # Maximum size, in bytes, of a request before it will be streamed to the
 # file system instead of into memory.

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -288,7 +288,6 @@ else:
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 
-
 PRIVATE_MEDIAFILES_LOCATION = ""
 # Django Storages configuration
 if config("USE_AWS_STORAGE", cast=bool, default=False):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -302,11 +302,11 @@ if config("USE_AWS_STORAGE", cast=bool, default=False):
     PRIVATE_MEDIAFILES_LOCATION = AWS_LOCATION + "/media"
     STATIC_FILES_LOCATION = AWS_LOCATION + "/static"
     DEFAULT_FILE_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.PrivateMediaStorage"
-    STATICFILES_STORAGE = "{{ cookiecutter.project_slug }}.utils.storages.StaticRootS3Boto3Storage"
+    STATICFILES_STORAGE = "instructionlibraries.utils.storages.StaticStorage"
     COLLECTFAST_STRATEGY = "collectfast.strategies.boto3.Boto3Strategy"
 
-    STATIC_URL = f"https://{aws_s3_domain}/{STATIC_FILES_LOCATION}/"
-    MEDIA_URL = f"https://{aws_s3_domain}/{PRIVATE_MEDIAFILES_LOCATION}/"
+    STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{STATIC_FILES_LOCATION}/"
+    MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{PRIVATE_MEDIAFILES_LOCATION}/"
 
 
 # Maximum size, in bytes, of a request before it will be streamed to the

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -1,11 +1,10 @@
 import os
+{%- if cookiecutter.use_graphql == 'y' %}
+from datetime import timedelta
+{%- endif %}
 
 import dj_database_url
-{% if cookiecutter.use_graphql == 'y' %}
-from datetime import timedelta
-{% endif %}
 from decouple import config
-
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -64,9 +63,9 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "django_filters",
     "django_extensions",
-    {% if cookiecutter.client_app == "React" -%}
+    {%- if cookiecutter.client_app == "React" %}
     "whitenoise.runserver_nostatic",
-    {%- endif -%}
+    {%- endif %}
     {% if cookiecutter.use_graphql == 'y' -%}
     "graphene_django"
     {% endif -%}
@@ -96,8 +95,7 @@ ROOT_URLCONF = "{{ cookiecutter.project_slug }}.urls"
 
 WSGI_APPLICATION = "{{ cookiecutter.project_slug }}.wsgi.application"
 
-{% if cookiecutter.use_graphql == 'y' -%}
-
+{%- if cookiecutter.use_graphql == 'y' %}
 GRAPHENE = {
     "SCHEMA": "{{ cookiecutter.project_slug }}.core.schema.schema",
     "MIDDLEWARE": [
@@ -115,8 +113,6 @@ AUTHENTICATION_BACKENDS = [
     "graphql_jwt.backends.JSONWebTokenBackend",
     "django.contrib.auth.backends.ModelBackend",
 ]
-
-
 {%- endif %}
 
 # Database
@@ -268,7 +264,7 @@ if not IN_DEV:
     EMAIL_USE_TLS = True
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-    {% endif %}
+    {%- endif %}
 
 # STORAGES
 # ----------------------------------------------------------------------------

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/utils/storages.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/utils/storages.py
@@ -1,0 +1,13 @@
+from django.conf import settings
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class StaticStorage(S3Boto3Storage):
+    location = settings.STATIC_FILES_LOCATION
+
+
+class PrivateMediaStorage(S3Boto3Storage):
+    location = settings.PRIVATE_MEDIAFILES_LOCATION
+    default_acl = "private"
+    file_overwrite = False
+    custom_domain = False


### PR DESCRIPTION
## What this does

There was a bug on the cookiecutter render, Grapehen was being rendered on the same line as the closing tag for INSTALLED_APPS causing a small bug

Additionally there was no fallback for when the index.html does not exist (aka when run build and collect static are not ran), since both react and vue can use the rendertemplate function I removed the if statements and had both use this new function. Additionally it seems the error thrown from the TemplateDoesNotExist does not get caught here so instead we check if the file exists and then render accordingly.

This should fix it!

- [ ] confirm works for vue
- [ ]  confirm works for react