### PR TITLE
Feature/ Vue 404 Page

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/vue3/src/router/index.js
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/router/index.js
@@ -41,7 +41,6 @@ const routes = [
   {
     path: '/:pathMatch(.*)*',
     name: 'PageNotFound',
-    beforeEnter: requireAuth,
     component: () => import('../views/PageNotFound.vue'),
   },
 ]

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/router/index.js
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/router/index.js
@@ -38,6 +38,12 @@ const routes = [
     beforeEnter: requireAuth,
     component: () => import(/* webpackChunkName: "dashboard" */ '../views/Dashboard.vue'),
   },
+  {
+    path: '/:pathMatch(.*)*',
+    name: 'PageNotFound',
+    beforeEnter: requireAuth,
+    component: () => import('../views/PageNotFound.vue'),
+  },
 ]
 
 const router = createRouter({

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -1,0 +1,18 @@
+<template>
+  <div class="page-not-found">
+    <h1><span class="error">404</span> Page Not Found</h1>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'PageNotFound',
+  components: {},
+}
+</script>
+
+<style scoped lang="scss">
+.error {
+  color: red;
+}
+</style>

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -12,7 +12,6 @@
 <script>
 export default {
   name: 'PageNotFound',
-  components: {},
 }
 </script>
 

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -1,6 +1,11 @@
 <template>
   <div class="page-not-found">
-    <h1><span class="error">404</span> Page Not Found</h1>
+    <h1 class="page-not-found__error">404</h1>
+    <img alt="Project Logo" src="../assets/logo.png" />
+    <h2 class="page-not-found__header">Oops!<br />We couldn't find the page you're looking for.</h2>
+    <p class="page-not-found__route">
+      Click <router-link to="/">here</router-link> to return to the home page.
+    </p>
   </div>
 </template>
 

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -17,7 +17,15 @@ export default {
 </script>
 
 <style scoped lang="scss">
-.error {
-  color: red;
+.page-not-found {
+  &__error {
+    margin: unset;
+    font-weight: 800;
+    font-size: 64px;
+  }
+
+  &__route {
+    font-size: 18px;
+  }
 }
 </style>


### PR DESCRIPTION
## What this does

Issue #43: Add default 404 page for Vue applications for any URL paths that are not currently defined in the project's Vue router.

## Checklist
- [x] Create new `PageNotFound.vue` view component to display if page is not found
- [x] Add new path routing in `/router/index.js` to handle paths that do not exist


## How to test

Either open the review app or create/run a bootstrapper app with this branch (`feature/vue-404-page`) and navigate to a URL that is not currently pathed with the Vue router (`/test`, for example) and you should be able to view the `PageNotFound` view, which has the 404 error code at the top, as well as some informational text.
