### PR TITLE
Cypress release trigger

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -66,27 +66,17 @@ jobs:
   Firefox:
     needs: Setup
     runs-on: ubuntu-latest
-    container:
-      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
-      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: |
-          # Cypress slim container image doesn't come with pipx
-          apt update -qq
-          apt install -y python3-venv python3-pip
-          # apt-get install python3-venv python3-pip
-          # python3 -m pip install pipx
-          # python3 -m pipx ensurepath
-          python3 -m pip install --user pipenv
+      - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
           cache: 'pipenv'
       - name: Install bootstrapper dependencies
-        run: python3 -m pipenv install --dev --deploy
-      - run: python3 -m pipenv run cookiecutter . --no-input -f
+        run: pipenv install --dev --deploy
+      - run: pipenv run cookiecutter . --no-input -f
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,9 +77,9 @@ jobs:
           apt update -qq
           apt install -y python3-venv python3-pip
           # apt-get install python3-venv python3-pip
-          python3 -m pip install pipx
-          python3 -m pipx ensurepath
-          pipx install pipenv
+          # python3 -m pip install pipx
+          # python3 -m pipx ensurepath
+          python3 -m pip install pipenv
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,11 +77,6 @@ jobs:
       - name: Install bootstrapper dependencies
         run: pipenv install --dev --deploy
       - run: pipenv run cookiecutter . --no-input -f
-      - name: Install frontend dependencies
-        env:
-          NPM_CONFIG_PRODUCTION: false
-        working-directory: ./my_project/client
-        run: npm install
   FirefoxRun:
     needs: Firefox
     runs-on: ubuntu-latest
@@ -89,6 +84,11 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
+      - name: Install frontend dependencies
+        env:
+          NPM_CONFIG_PRODUCTION: false
+        working-directory: ./my_project/client
+        run: npm install
       - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -49,7 +49,7 @@ jobs:
         working-directory: ./my_project/client
         run: npm install
       - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           working-directory: my_project/client
           browser: chrome

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -78,6 +78,7 @@ jobs:
           apt install -y python3-pip
           # apt-get install python3-venv python3-pip
           python3 -m pip install --user pipx
+          python3 -m pipx ensurepath
           pipx install pipenv
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,7 +67,7 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user root
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -9,12 +9,10 @@ jobs:
         id: findPr
       - name: Set URL for Staging
         if: github.ref_name == 'main'
-        run: |
-          echo "BASE_URL=https://tn-spa-bootstrapper-staging.herokuapp.com/" >> $GITHUB_ENV
+        run: echo "BASE_URL=https://tn-spa-bootstrapper-staging.herokuapp.com/" >> $GITHUB_ENV
       - name: Set URL for PR
         if: success() && steps.findPr.outputs.number
-        run: |
-          echo "BASE_URL=https://tn-spa-bootstrapper-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
+        run: echo "BASE_URL=https://tn-spa-bootstrapper-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
         env:
           PR: ${{ steps.findPr.outputs.pr }}
       - name: Raise for error

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
+          python -m ensurepip --upgrade
           python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          # python3 -m pip install --user pipx
+          python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -82,6 +82,13 @@ jobs:
           NPM_CONFIG_PRODUCTION: false
         working-directory: ./my_project/client
         run: npm install
+  FirefoxRun:
+    needs: Firefox
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      options: --user 1001
+    steps:
       - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
         uses: cypress-io/github-action@v4
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,6 +1,11 @@
 name: Cypress Tests
-on: workflow_call
-
+on:
+  workflow_call:
+    secrets:
+      CYPRESS_TEST_USER_EMAIL:
+        required: true
+      CYPRESS_TEST_USER_PASS:
+        required: true
 jobs:
   Setup:
     runs-on: ubuntu-latest
@@ -30,8 +35,8 @@ jobs:
     outputs:
       BASE_URL: ${{ env.BASE_URL }}
   Chrome:
-    runs-on: ubuntu-latest
     needs: Setup
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -53,15 +58,17 @@ jobs:
         with:
           working-directory: my_project/client
           browser: chrome
-          headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
           CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
           CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
           CYPRESS_baseUrl: ${{ needs.Setup.outputs.BASE_URL }}
   Firefox:
-    runs-on: ubuntu-latest
     needs: Setup
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -83,7 +90,6 @@ jobs:
         with:
           working-directory: my_project/client
           browser: firefox
-          headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
           CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,7 +74,9 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          apt-get install python3-venv python3-pip
+          apt update -qq
+          apt install -y python3-pip
+          # apt-get install python3-venv python3-pip
           python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -84,6 +84,10 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
+      - run: |
+          echo $(ls .)
+          echo $(ls my_project)
+          echo $(ls my_project/client)
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,7 +77,7 @@ jobs:
           apt update -qq
           apt install -y python3-pip
           # apt-get install python3-venv python3-pip
-          python3 -m pip install --user pipx
+          python3 -m pip install pipx
           python3 -m pipx ensurepath
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
-      options: --user root
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -79,7 +79,7 @@ jobs:
           # apt-get install python3-venv python3-pip
           # python3 -m pip install pipx
           # python3 -m pipx ensurepath
-          python3 -m pip install pipenv
+          python3 -m pip install --user pipenv
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,14 +67,14 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      image: cypress/browsers:node16.13.2-chrome100-ff98  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          python3 -m pip install --user pipx
+          # python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -67,7 +67,7 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     container:
-      image: cypress/browsers:node16.13.2-chrome100-ff98  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      image: cypress/browsers:cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user root
     steps:
       - name: Checkout

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,5 +1,6 @@
 name: Cypress Tests
-on: push
+on: workflow_call
+
 jobs:
   Setup:
     runs-on: ubuntu-latest
@@ -8,15 +9,28 @@ jobs:
         id: findPr
       - name: Set URL for Staging
         if: github.ref_name == 'main'
-        run: echo "BASE_URL=https://tn-spa-bootstrapper-staging.herokuapp.com/" >> $GITHUB_ENV
+        run: |
+          echo "BASE_URL=https://tn-spa-bootstrapper-staging.herokuapp.com/" >> $GITHUB_ENV
       - name: Set URL for PR
         if: success() && steps.findPr.outputs.number
-        run: echo "BASE_URL=https://tn-spa-bootstrapper-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
+        run: |
+          echo "BASE_URL=https://tn-spa-bootstrapper-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
         env:
           PR: ${{ steps.findPr.outputs.pr }}
       - name: Raise for error
         if: env.BASE_URL == ''
         run: exit 1
+      - name: Raise for maintenance mode
+        run: |
+          html_body=$(curl ${{ env.BASE_URL }})
+          if echo $html_body | grep -q "Offline for Maintenance";
+          then
+            exit 1
+          else
+            echo "NOT in maintenance. Likely Heroku trigger after successful deploy";
+          fi
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     outputs:
       BASE_URL: ${{ env.BASE_URL }}
   Chrome:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          python -m ensurepip --upgrade
+          python3 get-pip.py
           python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -75,7 +75,7 @@ jobs:
       - run: |
           # Cypress slim container image doesn't come with pipx
           apt update -qq
-          apt install -y python3-pip
+          apt install -y python3-venv python3-pip
           # apt-get install python3-venv python3-pip
           python3 -m pip install pipx
           python3 -m pipx ensurepath

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           name: my_project
           path: my_project/
+          retention-days: 1
     outputs:
       BASE_URL: ${{ env.BASE_URL }}
   Chrome:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node16.13.2-chrome100-ff98  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
-      options: --user 1001
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          python3 get-pip.py
+          sudo apt-get install python3-venv python3-pip
           python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,6 +80,7 @@ jobs:
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           pipx install pipenv
+          pipx ensurepath
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -80,14 +80,13 @@ jobs:
           python3 -m pip install pipx
           python3 -m pipx ensurepath
           pipx install pipenv
-          pipx ensurepath
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'
           cache: 'pipenv'
       - name: Install bootstrapper dependencies
-        run: pipenv install --dev --deploy
-      - run: pipenv run cookiecutter . --no-input -f
+        run: python3 -m pipenv install --dev --deploy
+      - run: python3 -m pipenv run cookiecutter . --no-input -f
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/checkout@v2
       - run: |
           # Cypress slim container image doesn't come with pipx
-          sudo apt-get install python3-venv python3-pip
+          apt-get install python3-venv python3-pip
           python3 -m pip install --user pipx
           pipx install pipenv
       - uses: actions/setup-python@v2

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,12 +32,6 @@ jobs:
           else
             echo "NOT in maintenance. Likely Heroku trigger after successful deploy";
           fi
-    outputs:
-      BASE_URL: ${{ env.BASE_URL }}
-  Chrome:
-    needs: Setup
-    runs-on: ubuntu-latest
-    steps:
       - name: Checkout
         uses: actions/checkout@v2
       - run: pipx install pipenv
@@ -48,6 +42,22 @@ jobs:
       - name: Install bootstrapper dependencies
         run: pipenv install --dev --deploy
       - run: pipenv run cookiecutter . --no-input -f
+      - uses: actions/upload-artifact@v3
+        with:
+          name: my_project
+          path: my_project/
+    outputs:
+      BASE_URL: ${{ env.BASE_URL }}
+  Chrome:
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: my_project
+          path: my_project/
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false
@@ -66,24 +76,6 @@ jobs:
   Firefox:
     needs: Setup
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - run: pipx install pipenv
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-          cache: 'pipenv'
-      - name: Install bootstrapper dependencies
-        run: pipenv install --dev --deploy
-      - run: pipenv run cookiecutter . --no-input -f
-      - uses: actions/upload-artifact@v3
-        with:
-          name: my_project
-          path: my_project/
-  FirefoxRun:
-    needs: Firefox
-    runs-on: ubuntu-latest
     container:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
@@ -94,10 +86,6 @@ jobs:
         with:
           name: my_project
           path: my_project/
-      - run: |
-          echo $(ls .)
-          echo $(ls my_project)
-          echo $(ls my_project/client)
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Install bootstrapper dependencies
         run: pipenv install --dev --deploy
       - run: pipenv run cookiecutter . --no-input -f
+      - uses: actions/upload-artifact@v3
+        with:
+          name: my_project
+          path: my_project/
   FirefoxRun:
     needs: Firefox
     runs-on: ubuntu-latest
@@ -84,6 +88,12 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/download-artifact@v3
+        with:
+          name: my_project
+          path: my_project/
       - run: |
           echo $(ls .)
           echo $(ls my_project)

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,8 +27,6 @@ jobs:
           else
             echo "NOT in maintenance. Likely Heroku trigger after successful deploy";
           fi
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     outputs:
       BASE_URL: ${{ env.BASE_URL }}
   Chrome:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -72,7 +72,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: pipx install pipenv
+      - run: |
+          # Cypress slim container image doesn't come with pipx
+          python3 -m pip install --user pipx
+          pipx install pipenv
       - uses: actions/setup-python@v2
         with:
           python-version: '3.9'

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -25,10 +25,6 @@ jobs:
           heroku maintenance:on --app=${{ needs.Setup.outputs.APP_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      - name: Set Github API key for callbacks coming from ${{ needs.Setup.outputs.APP_NAME }}
-        run: heroku config:set GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --app=${{ needs.Setup.outputs.APP_NAME }}
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -28,6 +28,9 @@ jobs:
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml
+    secrets:
+      CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
+      CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
   Maintenance-Off:
     if: ${{ always() }}
     needs: [Setup, Cypress]

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -27,6 +27,8 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       - name: Set Github API key for callbacks coming from ${{ needs.Setup.outputs.APP_NAME }}
         run: heroku config:set GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --app=${{ needs.Setup.outputs.APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -1,0 +1,41 @@
+name: Heroku
+on: [push]
+jobs:
+  Setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+      - name: Set app_name for Staging
+        run: echo "APP_NAME=tn-spa-bootstrapper-staging" >> $GITHUB_ENV
+      - name: Set app_name for PR
+        if: success() && steps.findPr.outputs.number
+        run: echo "APP_NAME=tn-spa-bootstrapper-pr-${PR}" >> $GITHUB_ENV
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+    outputs:
+      APP_NAME: ${{ env.APP_NAME }}
+  Maintenance-On:
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Turn Maintenance Mode On for ${{ needs.Setup.outputs.APP_NAME }} 
+        run: |
+          echo "Turning on maintenance so Cypress status starts as failing until rerun happens later."
+          heroku maintenance:on --app=${{ needs.Setup.outputs.APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  Cypress:
+    needs: Maintenance-On
+    uses: ./.github/workflows/cypress.yml
+  Maintenance-Off:
+    if: ${{ always() }}
+    needs: [Setup, Cypress]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Turn Maintenance Mode Off for ${{ needs.Setup.outputs.APP_NAME }} 
+        run: |
+          echo "Turning off maintenance so Heroku triggering rerun of Cypress will succeed";
+          heroku maintenance:off --app=${{ needs.Setup.outputs.APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
       - name: Set Github API key for callbacks coming from ${{ needs.Setup.outputs.APP_NAME }}
-        run: heroku config:set GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
+        run: heroku config:set GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} --app=${{ needs.Setup.outputs.APP_NAME }}
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -25,6 +25,8 @@ jobs:
           heroku maintenance:on --app=${{ needs.Setup.outputs.APP_NAME }}
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+      - name: Set Github API key for callbacks coming from ${{ needs.Setup.outputs.APP_NAME }}
+        run: heroku config:set GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -35,23 +35,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: pipx install pipenv
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-          cache: 'pipenv'
-      - name: Install bootstrapper dependencies
-        run: pipenv install --dev --deploy
-      - run: pipenv run cookiecutter . --no-input -f
-      - name: Install frontend dependencies
-        env:
-          NPM_CONFIG_PRODUCTION: false
-        working-directory: ./my_project/client
-        run: npm install
       - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
-          working-directory: my_project/client
+          working-directory: client
           browser: chrome
           headless: true
         env: 
@@ -65,23 +52,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - run: pipx install pipenv
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
-          cache: 'pipenv'
-      - name: Install bootstrapper dependencies
-        run: pipenv install --dev --deploy
-      - run: pipenv run cookiecutter . --no-input -f
-      - name: Install frontend dependencies
-        env:
-          NPM_CONFIG_PRODUCTION: false
-        working-directory: ./my_project/client
-        run: npm install
       - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
         uses: cypress-io/github-action@v4
         with:
-          working-directory: my_project/client
+          working-directory: client
           browser: firefox
           headless: true
         env: 

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -20,17 +20,15 @@ jobs:
         run: exit 1
       - name: Raise for maintenance mode
         run: |
-          html_body=$(curl ${{ env.BASE_URL }})
+          html_body=$(curl {{ "${{ env.BASE_URL }}" }})
           if echo $html_body | grep -q "Offline for Maintenance";
           then
             exit 1
           else
             echo "NOT in maintenance. Likely Heroku trigger after successful deploy";
           fi
-        env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     outputs:
-      BASE_URL: ${{ env.BASE_URL }}
+      BASE_URL: {{ "${{ env.BASE_URL }}" }}
   Chrome:
     runs-on: ubuntu-latest
     needs: Setup
@@ -50,7 +48,7 @@ jobs:
           NPM_CONFIG_PRODUCTION: false
         working-directory: ./my_project/client
         run: npm install
-      - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
+      - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
         uses: cypress-io/github-action@v2
         with:
           working-directory: my_project/client
@@ -58,9 +56,9 @@ jobs:
           headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
-          CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
-          CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
-          CYPRESS_baseUrl: ${{ needs.Setup.outputs.BASE_URL }}
+          CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
+          CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
+          CYPRESS_baseUrl: {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
   Firefox:
     runs-on: ubuntu-latest
     needs: Setup
@@ -80,7 +78,7 @@ jobs:
           NPM_CONFIG_PRODUCTION: false
         working-directory: ./my_project/client
         run: npm install
-      - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
+      - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
         uses: cypress-io/github-action@v4
         with:
           working-directory: my_project/client
@@ -88,6 +86,6 @@ jobs:
           headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
-          CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
-          CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
-          CYPRESS_baseUrl: ${{ needs.Setup.outputs.BASE_URL }}
+          CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
+          CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
+          CYPRESS_baseUrl: {{ "${{ needs.Setup.outputs.BASE_URL }}" }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -1,6 +1,11 @@
 name: Cypress Tests
-on: workflow_call
-
+on:
+  workflow_call:
+    secrets:
+      CYPRESS_TEST_USER_EMAIL:
+        required: true
+      CYPRESS_TEST_USER_PASS:
+        required: true
 jobs:
   Setup:
     runs-on: ubuntu-latest
@@ -30,8 +35,8 @@ jobs:
     outputs:
       BASE_URL: {{ "${{ env.BASE_URL }}" }}
   Chrome:
-    runs-on: ubuntu-latest
     needs: Setup
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -40,15 +45,17 @@ jobs:
         with:
           working-directory: client
           browser: chrome
-          headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
           CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
           CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
           CYPRESS_baseUrl: {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
   Firefox:
-    runs-on: ubuntu-latest
     needs: Setup
+    runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      options: --user 1001
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -57,7 +64,6 @@ jobs:
         with:
           working-directory: client
           browser: firefox
-          headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
           CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -1,7 +1,5 @@
 name: Cypress Tests
-on:
-  pull_request:
-    types: [opened]
+on: workflow_call
 
 jobs:
   Setup:
@@ -16,45 +14,80 @@ jobs:
         if: success() && steps.findPr.outputs.number
         run: echo "BASE_URL=https://{{ cookiecutter.project_slug }}-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
         env:
-          PR: {{ "${{ steps.findPr.outputs.pr }}" }}
+          PR: ${{ steps.findPr.outputs.pr }}
       - name: Raise for error
         if: env.BASE_URL == ''
         run: exit 1
-      - name: Raise for URL not up
-        run: curl --fail env.BASE_URL
+      - name: Raise for maintenance mode
+        run: |
+          html_body=$(curl ${{ env.BASE_URL }})
+          if echo $html_body | grep -q "Offline for Maintenance";
+          then
+            exit 1
+          else
+            echo "NOT in maintenance. Likely Heroku trigger after successful deploy";
+          fi
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
     outputs:
-      BASE_URL: {{ "${{ env.BASE_URL }}" }}
+      BASE_URL: ${{ env.BASE_URL }}
   Chrome:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: Setup
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
+      - run: pipx install pipenv
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+          cache: 'pipenv'
+      - name: Install bootstrapper dependencies
+        run: pipenv install --dev --deploy
+      - run: pipenv run cookiecutter . --no-input -f
+      - name: Install frontend dependencies
+        env:
+          NPM_CONFIG_PRODUCTION: false
+        working-directory: ./my_project/client
+        run: npm install
+      - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
         uses: cypress-io/github-action@v2
         with:
-          working-directory: client
+          working-directory: my_project/client
           browser: chrome
           headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
-          CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
-          CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
-          CYPRESS_baseUrl: {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
+          CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
+          CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
+          CYPRESS_baseUrl: ${{ needs.Setup.outputs.BASE_URL }}
   Firefox:
     runs-on: ubuntu-latest
     needs: Setup
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Run against {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
-        uses: cypress-io/github-action@v2
+      - run: pipx install pipenv
+      - uses: actions/setup-python@v2
         with:
-          working-directory: client
+          python-version: '3.9'
+          cache: 'pipenv'
+      - name: Install bootstrapper dependencies
+        run: pipenv install --dev --deploy
+      - run: pipenv run cookiecutter . --no-input -f
+      - name: Install frontend dependencies
+        env:
+          NPM_CONFIG_PRODUCTION: false
+        working-directory: ./my_project/client
+        run: npm install
+      - name: Run against ${{ needs.Setup.outputs.BASE_URL }}
+        uses: cypress-io/github-action@v4
+        with:
+          working-directory: my_project/client
           browser: firefox
           headless: true
         env: 
           NPM_CONFIG_PRODUCTION: false
-          CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
-          CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
-          CYPRESS_baseUrl: {{ "${{ needs.Setup.outputs.BASE_URL }}" }}
+          CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
+          CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
+          CYPRESS_baseUrl: ${{ needs.Setup.outputs.BASE_URL }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -1,5 +1,8 @@
 name: Cypress Tests
-on: push
+on:
+  pull_request:
+    types: [opened]
+
 jobs:
   Setup:
     runs-on: ubuntu-latest
@@ -17,6 +20,8 @@ jobs:
       - name: Raise for error
         if: env.BASE_URL == ''
         run: exit 1
+      - name: Raise for URL not up
+        run: curl --fail env.BASE_URL
     outputs:
       BASE_URL: {{ "${{ env.BASE_URL }}" }}
   Chrome:

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
         if: success() && steps.findPr.outputs.number
         run: echo "BASE_URL=https://{{ cookiecutter.project_slug }}-pr-${PR}.herokuapp.com/" >> $GITHUB_ENV
         env:
-          PR: ${{ steps.findPr.outputs.pr }}
+          PR: {{ "${{ steps.findPr.outputs.pr }}" }}
       - name: Raise for error
         if: env.BASE_URL == ''
         run: exit 1

--- a/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
@@ -28,6 +28,9 @@ jobs:
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml
+    secrets:
+      CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
+      CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
   Maintenance-Off:
     if: {{ "${{ always() }}" }}
     needs: [Setup, Cypress]

--- a/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
@@ -1,0 +1,41 @@
+name: Heroku
+on: [push]
+jobs:
+  Setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+      - name: Set app_name for Staging
+        run: echo "APP_NAME={{ cookiecutter.project_slug }}-staging" >> $GITHUB_ENV
+      - name: Set app_name for PR
+        if: success() && steps.findPr.outputs.number
+        run: echo "APP_NAME={{ cookiecutter.project_slug }}-pr-${PR}" >> $GITHUB_ENV
+        env:
+          PR: ${{ steps.findPr.outputs.pr }}
+    outputs:
+      APP_NAME: ${{ env.APP_NAME }}
+  Maintenance-On:
+    needs: Setup
+    runs-on: ubuntu-latest
+    steps:
+      - name: Turn Maintenance Mode On for ${{ needs.Setup.outputs.APP_NAME }} 
+        run: |
+          echo "Turning on maintenance so Cypress status starts as failing until rerun happens later."
+          heroku maintenance:on --app=${{ needs.Setup.outputs.APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+  Cypress:
+    needs: Maintenance-On
+    uses: ./.github/workflows/cypress.yml
+  Maintenance-Off:
+    if: ${{ always() }}
+    needs: [Setup, Cypress]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Turn Maintenance Mode Off for ${{ needs.Setup.outputs.APP_NAME }} 
+        run: |
+          echo "Turning off maintenance so Heroku triggering rerun of Cypress will succeed";
+          heroku maintenance:off --app=${{ needs.Setup.outputs.APP_NAME }}
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
@@ -12,30 +12,30 @@ jobs:
         if: success() && steps.findPr.outputs.number
         run: echo "APP_NAME={{ cookiecutter.project_slug }}-pr-${PR}" >> $GITHUB_ENV
         env:
-          PR: ${{ steps.findPr.outputs.pr }}
+          PR: {{ "${{ steps.findPr.outputs.pr }}" }}
     outputs:
-      APP_NAME: ${{ env.APP_NAME }}
+      APP_NAME: {{ "${{ env.APP_NAME }}" }}
   Maintenance-On:
     needs: Setup
     runs-on: ubuntu-latest
     steps:
-      - name: Turn Maintenance Mode On for ${{ needs.Setup.outputs.APP_NAME }} 
+      - name: Turn Maintenance Mode On for {{ "${{ needs.Setup.outputs.APP_NAME }}" }} 
         run: |
           echo "Turning on maintenance so Cypress status starts as failing until rerun happens later."
-          heroku maintenance:on --app=${{ needs.Setup.outputs.APP_NAME }}
+          heroku maintenance:on --app={{ "${{ needs.Setup.outputs.APP_NAME }}" }}
         env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_API_KEY: {{ "${{ secrets.HEROKU_API_KEY }}" }}
   Cypress:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml
   Maintenance-Off:
-    if: ${{ always() }}
+    if: {{ "${{ always() }}" }}
     needs: [Setup, Cypress]
     runs-on: ubuntu-latest
     steps:
-      - name: Turn Maintenance Mode Off for ${{ needs.Setup.outputs.APP_NAME }} 
+      - name: Turn Maintenance Mode Off for {{ "${{ needs.Setup.outputs.APP_NAME }}" }} 
         run: |
           echo "Turning off maintenance so Heroku triggering rerun of Cypress will succeed";
-          heroku maintenance:off --app=${{ needs.Setup.outputs.APP_NAME }}
+          heroku maintenance:off --app={{ "${{ needs.Setup.outputs.APP_NAME }}" }}
         env:
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+          HEROKU_API_KEY: {{ "${{ secrets.HEROKU_API_KEY }}" }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/heroku_deploy.yml
@@ -29,8 +29,8 @@ jobs:
     needs: Maintenance-On
     uses: ./.github/workflows/cypress.yml
     secrets:
-      CYPRESS_TEST_USER_EMAIL: ${{ secrets.CYPRESS_TEST_USER_EMAIL }}
-      CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
+      CYPRESS_TEST_USER_EMAIL: {{ "${{ secrets.CYPRESS_TEST_USER_EMAIL }}" }}
+      CYPRESS_TEST_USER_PASS: {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
   Maintenance-Off:
     if: {{ "${{ always() }}" }}
     needs: [Setup, Cypress]

--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -14,6 +14,6 @@ web: gunicorn {{ cookiecutter.project_slug }}.wsgi --chdir=server --log-file -
 #   3. Up-to-date build numbers shown in app (ideally auto-generated at build-and-deploy time)
 #
 # Comment the line below to disable migrations automatically after a Heroku push.
-release: python server/manage.py makemigrations --noinput && python server/manage.py migrate --noinput
+release: python server/manage.py makemigrations --noinput && python server/manage.py migrate --noinput && ./scripts/release.sh
 
 

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -5,7 +5,7 @@
 ## Setup
 
 ### Github & Heroku
-1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can research Heroku
+1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can reach Heroku
 1. [Generate an auth token for Github](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) in Heroku so Heroku can trigger Github Actions
 
 ### Docker

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -4,6 +4,10 @@
 
 ## Setup
 
+### Github & Heroku
+1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can research Heroku
+1. [Generate an auth token for Github](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) in Heroku so Heroku can trigger Github Actions
+
 ### Docker
 If this is your first time...
 1. [Install Docker](https://www.docker.com/)

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -5,8 +5,8 @@
 ## Setup
 
 ### Github & Heroku
-1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can reach Heroku
-1. [Generate an auth token for Github](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) in Heroku so Heroku can trigger Github Actions
+1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can reach Heroku. `heroku authorizations:create -d "Github Actions" -s write-protected`
+1. [Generate an auth token for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-with-the-api) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) in Heroku so Heroku can trigger Github Actions
 
 ### Docker
 If this is your first time...

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -6,7 +6,7 @@
 
 ### Github & Heroku
 1. [Generate an auth token for Heroku](https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-authorizations-create) and add it to the [repo secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) so Github Actions can reach Heroku. `heroku authorizations:create -d "Github Actions" -s write-protected`
-1. [Generate an auth token for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-with-the-api) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) in Heroku so Heroku can trigger Github Actions
+1. [Generate an auth token for Github](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github#authenticating-with-the-api) and add it as [an environment variable](https://devcenter.heroku.com/articles/config-vars) so Heroku can trigger Github Actions
 
 ### Docker
 If this is your first time...

--- a/{{cookiecutter.project_slug}}/scripts/release.sh
+++ b/{{cookiecutter.project_slug}}/scripts/release.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /app
+
+python3 server/manage.py trigger_cypress

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/trigger_cypress.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/trigger_cypress.py
@@ -1,0 +1,39 @@
+import requests
+from decouple import config
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Rerun Cypress Github Action now that Heroku has finished deploying"
+    headers = {
+        "Authorization": "",
+        "Content-Type": "application/json",
+        "Accept": "application/vnd.github+json"
+    }
+    github_root = None
+
+    def find_cypress_workflow_id(self, branch):
+        list_workflows_url = f"{self.github_root}/actions/runs"
+        r = requests.get(list_workflows_url, headers=self.headers).json()
+        return [a["id"] for a in r["workflow_runs"] if a["name"] == "Heroku" and a["head_branch"] == branch][0]
+
+    def find_job_id_for_cypress_step(self, workflow_id):
+        list_jobs_url = f"{self.github_root}/actions/runs/{workflow_id}/jobs"
+        r = requests.get(list_jobs_url, headers=self.headers).json()
+        return [a["id"] for a in r["jobs"] if a["name"] == "Cypress / Setup"][0]
+
+    def rerun_job(self, job_id):
+        rerun_job_url = f"{self.github_root}/actions/jobs/{job_id}/rerun"
+        print(f"Rerunning Cypress now that code is deployed: {rerun_job_url}")
+        requests.post(rerun_job_url, headers=self.headers)
+
+    def handle(self, *args, **kwargs):
+        self.headers["Authorization"] = f"Bearer {config('GITHUB_TOKEN')}"
+        org = "thinknimble"
+        repo = "tn-spa-bootstrapper"
+        branch = config("HEROKU_BRANCH")
+        self.github_root = f"https://api.github.com/repos/{org}/{repo}"
+
+        workflow_id = self.find_cypress_workflow_id(branch)
+        job_id = self.find_job_id_for_cypress_step(workflow_id)
+        self.rerun_job(job_id)


### PR DESCRIPTION
Better way to run Cypress for Review Apps

Addresses https://github.com/thinknimble/tn-spa-bootstrapper/issues/88

- [x] Github Action turns on Heroku maintenance mode temporarily so Cypress defaults to failing
- [x] Heroku deployments call a release script
- [x] Release script calls Github API to trigger a rerun of the failing Cypress run
- [x] 2nd run of Cypress passes and is now guaranteed to be testing the most current version of deployed code
- [x] Document secret generation for devs

TODO:
- [x] Implement feature and/or fix bug
- [x] Add and/or fix tests
- [x] Review App looks good
- [x] Code Review
- [x] During merge...remove `NPM_PRIVATE_TOKEN` from Github and Heroku settings
- [x] During merge...generate new `GITHUB_TOKEN` and add it to the pipeline and staging settings in Heroku
- [x] During merge...generate new `HEROKU_API_KEY` and replace the old one in Github settings