### PR TITLE
Pinned DRF minor version to 3.13

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -12,7 +12,7 @@ django-rest-auth = "==0.9.5"
 dj-database-url = "==0.5.0"
 django-storages = "==1.11.1"  # https://github.com/jschneier/django-storages
 boto3 = "==1.18.26"
-djangorestframework = "==3.*"
+djangorestframework = "==3.13.*"
 gunicorn = "==20.1.0"
 python-decouple = "*"
 pytz = "==2021.1"


### PR DESCRIPTION
Fixes a bug that seems was introduced in a newer minor version of `djangorestframework`.
When running `manage.py migrate` or `runserver` :

```
  File "/Users/bruno/.local/share/virtualenvs/testing_daisy_ui-ilWChcCQ/lib/python3.9/site-packages/drf_yasg/inspectors/field.py", line 406, in <module>
    (serializers.NullBooleanField, (openapi.TYPE_BOOLEAN, None)),
AttributeError: module 'rest_framework.serializers' has no attribute 'NullBooleanField'

```
