### PR TITLE
index.html template fallback for React apps

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -31,10 +31,7 @@ from .serializers import UserLoginSerializer, UserSerializer
 @ensure_csrf_cookie
 @never_cache
 def index(request):
-    try:
-        return TemplateResponse(request, "index.html")
-    except TemplateDoesNotExist:
-        return TemplateResponse(request, "core/index-placeholder.html")
+    return TemplateResponse(request, ["index.html", "core/index-placeholder.html"])
 {% elif cookiecutter.client_app.lower() == 'None' %}
 def index(request):
     return redirect(to="/docs/swagger/")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -5,29 +5,36 @@ from django.db import transaction
 from django.shortcuts import render
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
+
 {% if cookiecutter.use_graphql == 'y' %}from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import ensure_csrf_cookie
+
 {% endif %}from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-
-from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
+from {{cookiecutter.project_slug}}.utils.emails import send_html_email
 
 from .models import User
 from .permissions import CreateOnlyPermissions
+
 {% if cookiecutter.use_graphql == 'n' -%}
 from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
+
 {% else %}
 from .serializers import UserLoginSerializer, UserSerializer
+
 {% endif %}
 {% if cookiecutter.use_graphql == 'y' %}
 # Serve React frontend
 @ensure_csrf_cookie
 @never_cache
 def index(request):
-    return TemplateResponse(request, "index.html")
+    try:
+        return TemplateResponse(request, "index.html")
+    except TemplateDoesNotExist:
+        return TemplateResponse(request, "core/index-placeholder.html")
 {% elif cookiecutter.client_app.lower() == 'None' %}
 def index(request):
     return redirect(to="/docs/swagger/")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -7,18 +7,19 @@ from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
 {% if cookiecutter.use_graphql == 'y' %}from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
-from django.views.decorators.csrf import ensure_csrf_cookie
-{% endif %}
-from rest_framework import generics, mixins, permissions, status, viewsets
+from django.views.decorators.csrf import ensure_csrf_cookie{% endif %}from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
+
 from {{cookiecutter.project_slug}}.utils.emails import send_html_email
+
 from .models import User
 from .permissions import CreateOnlyPermissions
 {% if cookiecutter.use_graphql == 'n' -%}from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer{% else %}
 from .serializers import UserLoginSerializer, UserSerializer
 {% endif %}
+
 {% if cookiecutter.use_graphql == 'y' %}
 # Serve React frontend
 @ensure_csrf_cookie

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -8,21 +8,17 @@ from django.template.loader import render_to_string
 {% if cookiecutter.use_graphql == 'y' %}from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import ensure_csrf_cookie
-{% endif %}from rest_framework import generics, mixins, permissions, status, viewsets
+{% endif %}
+from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 from {{cookiecutter.project_slug}}.utils.emails import send_html_email
-
 from .models import User
 from .permissions import CreateOnlyPermissions
-{% if cookiecutter.use_graphql == 'n' -%}
-from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
-{% else %}
+{% if cookiecutter.use_graphql == 'n' -%}from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer{% else %}
 from .serializers import UserLoginSerializer, UserSerializer
 {% endif %}
-
-
 {% if cookiecutter.use_graphql == 'y' %}
 # Serve React frontend
 @ensure_csrf_cookie

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -5,11 +5,9 @@ from django.db import transaction
 from django.shortcuts import render
 from django.template.exceptions import TemplateDoesNotExist
 from django.template.loader import render_to_string
-
 {% if cookiecutter.use_graphql == 'y' %}from django.template.response import TemplateResponse
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import ensure_csrf_cookie
-
 {% endif %}from rest_framework import generics, mixins, permissions, status, viewsets
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import ValidationError
@@ -18,14 +16,13 @@ from {{cookiecutter.project_slug}}.utils.emails import send_html_email
 
 from .models import User
 from .permissions import CreateOnlyPermissions
-
 {% if cookiecutter.use_graphql == 'n' -%}
 from .serializers import UserLoginSerializer, UserRegistrationSerializer, UserSerializer
-
 {% else %}
 from .serializers import UserLoginSerializer, UserSerializer
-
 {% endif %}
+
+
 {% if cookiecutter.use_graphql == 'y' %}
 # Serve React frontend
 @ensure_csrf_cookie


### PR DESCRIPTION
## What this does

React issue reported by Jennifer: favicon and metatag link calls in `index.html` of the React app create a server error: `TemplateDoesNotExist`.

The problem is twofold:
1. We don't really need those metatags in development, but since they are in index.html, the browser is requesting them, and the React dev server is proxying those requests to the backend for some reason.
2. Our Django app is configured to look for the client-side `index.html` template in `client/dist/`, but in development - as intended - this folder does not exist yet, b/c we have not built the frontend for production. The `favicon_urls` config is disabled in development, so it falls back to serving `index.html`, which fails with a `TemplateDoesNotExist error.

I think the quick fix is to add this fall back to `index-placeholder.html`, which was a strategy we were using with Vue. We should also look into configuring React to NOT proxy these calls for favicons to the backend OR add template tags to disable the meta tags altogether in dev.

## How to test

Bootstrap a React app w/ GraphQL enabled and run the client-side dev server.