### PR TITLE
Improve Swagger default settings

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,7 +32,7 @@
     "addons": ["heroku-postgresql:standard-0"],
     "environments": {
         "review": {
-            "addons": ["heroku-postgresql:hobby-dev"]
+            "addons": ["heroku-postgresql:mini"]
         }
     },
     "buildpacks": [

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -11,7 +11,7 @@
     "clients/vue3/src/views/dashboard",
     "clients/vue3/src/components",
     "clients/react/src/pages",
-    "server/{{cookiecutter.project_slug}}/client"
+    "*/swagger-ui.html"
   ],
   "mail_service": ["Mailgun", "Amazon SES", "Custom SMTP"],
   "use_graphql": "n",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,8 @@
   "_copy_without_render": [
     "clients/vue3/src/views/dashboard",
     "clients/vue3/src/components",
-    "clients/react/src/pages"
+    "clients/react/src/pages",
+    "server/{{cookiecutter.project_slug}}/client"
   ],
   "mail_service": ["Mailgun", "Amazon SES", "Custom SMTP"],
   "use_graphql": "n",

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -8,7 +8,7 @@ Django = "==3.2.6"
 django-extensions = "==3.1.3"
 django-filter = "==2.4.0"
 django-nose = "==1.4.7"
-django-rest-auth = "==0.9.5"
+dj-rest-auth = "*"
 dj-database-url = "==0.5.0"
 django-storages = "==1.11.1"  # https://github.com/jschneier/django-storages
 boto3 = "==1.18.26"

--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -14,7 +14,7 @@
             "value": "development"
         },
         "PROJECT_PATH": {
-            "value": "modat_api"
+            "value": "{{ cookiecutter.project_slug }}"
         },
         "NPM_CONFIG_PRODUCTION": {
             "value": "false"

--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -30,7 +30,7 @@
     "environments": {
         "review": {
             "addons": [
-                "heroku-postgresql:hobby-dev",
+                "heroku-postgresql:mini",
                 "papertrail:Choklad"
             ]
         }

--- a/{{cookiecutter.project_slug}}/clients/react/public/index.html
+++ b/{{cookiecutter.project_slug}}/clients/react/public/index.html
@@ -39,10 +39,10 @@
     <!-- Facebook Unfurling Meta Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%PUBLIC_URL%" />
-    <meta property="og:title" content="Squirrel" />
+    <meta property="og:title" content="{{ cookiecutter.project_name }}" />
     <meta property="og:description" content="Add a description for {{ cookiecutter.project_name }} in index.html!" />
     <meta property="og:image" content="%PUBLIC_URL%/static/meta-preview.png" />
-    
+
     <!-- Twitter Unfurling Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <!-- TODO: Add the app domain here once live. -->

--- a/{{cookiecutter.project_slug}}/clients/vue3/public/index.html
+++ b/{{cookiecutter.project_slug}}/clients/vue3/public/index.html
@@ -40,10 +40,10 @@
     <!-- Facebook Unfurling Meta Tags -->
     <meta property="og:type" content="website" />
     <meta property="og:url" content="%PUBLIC_URL%" />
-    <meta property="og:title" content="Squirrel" />
+    <meta property="og:title" content="{{ cookiecutter.project_name }}" />
     <meta property="og:description" content="Add a description for {{ cookiecutter.project_name }} in index.html!" />
     <meta property="og:image" content="%PUBLIC_URL%/static/meta-preview.png" />
-    
+
     <!-- Twitter Unfurling Meta Tags -->
     <meta name="twitter:card" content="summary_large_image">
     <!-- TODO: Add the app domain here once live. -->

--- a/{{cookiecutter.project_slug}}/scripts/deploy-on-heroku.sh
+++ b/{{cookiecutter.project_slug}}/scripts/deploy-on-heroku.sh
@@ -6,7 +6,7 @@
 APP_NAME={{ cookiecutter.project_slug }}-staging.herokuapp.com
 heroku login --interactive
 heroku create $APP_NAME --buildpack heroku/python
-heroku addons:create heroku-postgresql:hobby-dev --app $APP_NAME
+heroku addons:create heroku-postgresql:mini --app $APP_NAME
 
 {%- if cookiecutter.client_app.lower() != "none" %}
 heroku buildpacks:add --index 1 heroku/nodejs --app $APP_NAME

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/client/templates/drf-yasg/swagger-ui.html
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/client/templates/drf-yasg/swagger-ui.html
@@ -1,0 +1,18 @@
+{% extends "drf-yasg/swagger-ui.html" %}
+
+{% block extra_scripts %}
+    <script>
+        let authorization = {
+            Token: {
+                name: "Token",
+                schema: {
+                    type: "apiKey",
+                    "in": "header",
+                },
+                value: "Token {{ user.auth_token.key | safe }}"
+            }
+        }
+
+        localStorage.setItem(KEY_AUTH, JSON.stringify(Immutable.fromJS(authorization)))
+    </script>
+{% endblock %}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/models.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/models.py
@@ -3,6 +3,9 @@ import uuid  # noqa
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.contrib.auth.tokens import default_token_generator
 from django.db import models
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from rest_framework.authtoken.models import Token
 
 from {{ cookiecutter.project_slug }}.common.models import AbstractBaseModel
 from {{ cookiecutter.project_slug }}.utils import sites as site_utils
@@ -69,3 +72,9 @@ class User(AbstractUser, AbstractBaseModel):
 
     class Meta:
         ordering = ["email"]
+
+
+@receiver(post_save, sender=User)
+def create_auth_token_add_permissions(sender, instance, created, **kwargs):
+    if created:
+        Token.objects.create(user=instance)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
@@ -38,8 +38,8 @@ schema_view = get_schema_view(
         contact=openapi.Contact(email="support@{{ cookiecutter.project_slug }}.com"),
         license=openapi.License(name="BSD License"),
     ),
-    public=True,
-    permission_classes=[permissions.AllowAny],
+    public=False,
+    permission_classes=[permissions.IsAuthenticated],
 )
 
 urlpatterns = urlpatterns + [

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
@@ -1,9 +1,9 @@
+from dj_rest_auth import views as rest_auth_views
 from django.conf import settings
 from django.conf.urls.static import static
 from django.urls import include, path, re_path
 from drf_yasg import openapi
 from drf_yasg.views import get_schema_view
-from rest_auth import views as rest_auth_views
 from rest_framework import permissions
 from rest_framework_nested import routers
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
@@ -38,8 +38,8 @@ schema_view = get_schema_view(
         contact=openapi.Contact(email="support@{{ cookiecutter.project_slug }}.com"),
         license=openapi.License(name="BSD License"),
     ),
-    public=False,
-    permission_classes=[permissions.IsAuthenticated],
+    public=True,
+    permission_classes=[permissions.AllowAny],
 )
 
 urlpatterns = urlpatterns + [

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/views.py
@@ -41,7 +41,6 @@ def index(request):
 {% endif %}
 
 class UserLoginView(generics.GenericAPIView):
-    swagger_schema = None
     serializer_class = UserLoginSerializer
     authentication_classes = ()
     permission_classes = ()
@@ -69,7 +68,6 @@ class UserViewSet(
     mixins.ListModelMixin,
     mixins.UpdateModelMixin,
 ):
-    swagger_schema = None
     queryset = User.objects.all()
     serializer_class = UserSerializer
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -65,6 +65,7 @@ INSTALLED_APPS = [
     "django_nose",
     "rest_framework",
     "rest_framework.authtoken",
+    "dj_rest_auth",
     "django_filters",
     "django_extensions",
     {% if cookiecutter.use_graphql == 'y' -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -119,10 +119,12 @@ TEMPLATES = [
         "APP_DIRS": True,
         "DIRS": [
             os.path.join(BASE_DIR, "../client/dist/"),
+            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"),  # Swagger template override
         ],
         {% else -%}
         "DIRS": [
             os.path.join(BASE_DIR, "..", "client", "build"),
+            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"),  # Swagger template override
         ],
         "APP_DIRS": True,  # this setting must come after "DIRS"!
         {% endif -%}
@@ -423,3 +425,15 @@ CORS_ALLOWED_ORIGINS.append("http://localhost:3000")
 {% if cookiecutter.use_graphql == 'y' %}
 CORS_ALLOW_CREDENTIALS = True
 {% endif -%}
+
+SWAGGER_SETTINGS = {
+    "LOGIN_URL": "/login",
+    "USE_SESSION_AUTH": False,
+    "PERSIST_AUTH": True,
+    "SECURITY_DEFINITIONS": {
+        "Token": {"type": "apiKey", "name": "Authorization", "in": "header"},
+    },
+    "JSON_EDITOR": True,
+    "SHOW_REQUEST_HEADERS": True,
+    "OPERATIONS_SORTER": "alpha",
+}


### PR DESCRIPTION
## What this does

A bunch of small quality of life improvements, mostly with how we generate the Swagger backend API docs. See list below. 

## Checklist
- [x] Swagger docs public by default
- [x] Generate API keys on user creation instead of login
- [x] Swagger "Try it Out" feature works and uses the users own API key in the example `curl`
- [x] Update Heroku config to use `mini` for Postgres on Review Apps
- [x] Remove hardcoded references


## Deploy Notes

n/a

## How to test

View Swagger docs in Heroku.
Use the "Try it Out" Swagger feature and observe that the example `curl` request uses an auth token and not session auth.
