### PR TITLE
Fix/Vue 404 page styling

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/Home.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col items-center">
     <img alt="Project Logo" src="../assets/logo.png" />
-    <h1>Welcome to {{cookiecutter.project_name}}!</h1>
+    <h1 class="heading">Welcome to {{ cookiecutter.project_name }}!</h1>
   </div>
 </template>
 
@@ -9,6 +9,6 @@
 export default {
   name: 'Home',
   components: {},
-  setup(){}
+  setup() {},
 }
 </script>

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -3,9 +3,7 @@
     <h1 class="text-7xl font-extrabold">404</h1>
     <img alt="Project Logo" src="../assets/logo.png" />
     <h2 class="text-xl font-bold mb-4">Oops!<br />We couldn't find the page you're looking for.</h2>
-    <p class="text-xl underline">
-      Click <router-link to="/">here</router-link> to return to the home page.
-    </p>
+    <router-link to="/" class="text-xl underline">Return to the home page.</router-link>
   </div>
 </template>
 

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -2,7 +2,7 @@
   <div class="flex flex-col items-center">
     <h1 class="text-7xl font-extrabold">404</h1>
     <img alt="Project Logo" src="../assets/logo.png" />
-    <h2 class="text-xl font-bold mb-4">Oops!<br />We couldn't find the page you're looking for.</h2>
+    <h2 class="text-xl font-bold mb-4">We couldn't find the page you're looking for.</h2>
     <router-link to="/" class="text-xl underline">Return to the home page.</router-link>
   </div>
 </template>

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -14,17 +14,3 @@ export default {
   name: 'PageNotFound',
 }
 </script>
-
-<style scoped lang="scss">
-.page-not-found {
-  &__error {
-    margin: unset;
-    font-weight: 800;
-    font-size: 64px;
-  }
-
-  &__route {
-    font-size: 18px;
-  }
-}
-</style>

--- a/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
+++ b/{{cookiecutter.project_slug}}/clients/vue3/src/views/PageNotFound.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="page-not-found">
-    <h1 class="page-not-found__error">404</h1>
+  <div class="flex flex-col items-center">
+    <h1 class="text-7xl font-extrabold">404</h1>
     <img alt="Project Logo" src="../assets/logo.png" />
-    <h2 class="page-not-found__header">Oops!<br />We couldn't find the page you're looking for.</h2>
-    <p class="page-not-found__route">
+    <h2 class="text-xl font-bold mb-4">Oops!<br />We couldn't find the page you're looking for.</h2>
+    <p class="text-xl underline">
       Click <router-link to="/">here</router-link> to return to the home page.
     </p>
   </div>


### PR DESCRIPTION
## What this does

Update styling for the `PageNotFound` 404 page to use Tailwind styling (as well as fix the styling issues that ended up broken due to prior Tailwind implementation).

Add `heading` custom Tailwind class styling to `<h1>` tag on "welcome" main page.

## Checklist
- [x] Style `PageNotFound` view with Tailwind
- [x] Update 404 screen text + router link for home page to be more screen-reader accessible / friendly.
- [x] Add `heading` class to "Welcome to {project}" text `<h1>` tag in `Home` view


## How to test

Open the review app and navigate to a non-existing page to check the 404 page styling with TailwindCSS.
