### PR TITLE
Add a JSON Web Token Authentication class for DRF

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -1,8 +1,7 @@
+import secrets
 from os import remove, rename
 from os.path import exists, join
-import secrets
 from shutil import copy2, move, rmtree
-
 
 END = "\x1b[0m"
 QUESTION = "\x1b[0;36m [QUESTION]: "
@@ -91,6 +90,7 @@ def remove_graphql_files():
         join("server/{{ cookiecutter.project_slug }}/core", "schema.py"),
         join("server/{{ cookiecutter.project_slug }}/core", "types.py"),
         join("server/{{ cookiecutter.project_slug }}/core", "mutations.py"),
+        join("server/{{ cookiecutter.project_slug }}/core", "jwt_auth.py"),
     ]
     for file_name in file_names:
         if exists(file_name):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/jwt_auth.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/jwt_auth.py
@@ -1,0 +1,58 @@
+from graphql_jwt.exceptions import JSONWebTokenError
+from graphql_jwt.utils import get_payload, get_user_by_payload
+from rest_framework import exceptions
+from rest_framework.authentication import BaseAuthentication, get_authorization_header
+
+
+class JSONWebTokenAuthentication(BaseAuthentication):
+    """Authentication class that enables us to use JWTs on Django Rest Framework endpoints.
+
+    Usage Example:
+
+        from rest_framework import permissions
+        from rest_framework.decorators import api_view, authentication_classes, permission_classes
+        from rest_framework.response import Response
+
+        from my_project.core.jwt_auth import JSONWebTokenAuthentication
+
+        @api_view(["get"])
+        @permission_classes([permissions.IsAuthenticated])
+        @authentication_classes([JSONWebTokenAuthentication])
+        def my_amazing_view(request, *args, **kwargs):
+            return Response("Hello World")
+    """
+
+    keyword = "JWT"
+
+    def authenticate(self, request):
+        auth = get_authorization_header(request).split()
+
+        if not auth or auth[0].lower() != self.keyword.lower().encode():
+            return None
+
+        if len(auth) == 1:
+            msg = "Invalid token header. No credentials provided."
+            raise exceptions.AuthenticationFailed(msg)
+        elif len(auth) > 2:
+            msg = "Invalid token header. Token string should not contain spaces."
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            token = auth[1].decode()
+        except UnicodeError:
+            msg = "Invalid token header. Token string should not contain invalid characters."
+            raise exceptions.AuthenticationFailed(msg)
+
+        try:
+            payload = get_payload(token)
+            user = get_user_by_payload(payload)
+        except JSONWebTokenError as e:
+            raise exceptions.AuthenticationFailed(str(e))
+
+        if user is None or not user.is_active:
+            raise exceptions.AuthenticationFailed("User inactive or deleted.")
+
+        return (user, None)
+
+    def authenticate_header(self, request):
+        return self.keyword

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -198,7 +198,11 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_PAGINATION_CLASS": "{{ cookiecutter.project_slug }}.core.pagination.PageNumberPagination",
     "DEFAULT_AUTHENTICATION_CLASSES": [
+        {% if cookiecutter.use_graphql == 'y' -%}
+        "{{ cookiecutter.project_slug }}.core.jwt_auth.JSONWebTokenAuthentication",
+        {% else -%}
         "rest_framework.authentication.TokenAuthentication",
+        {% endif -%}
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_RENDERER_CLASSES": [


### PR DESCRIPTION
## What this does

Our current GraphQL setup uses JWTs for authentication.

This PR adds a `JSONWebTokenAuthentication` class that can be used with Django Rest Framework API Views. So the same JWT that is used to authenticate GraphQL endpoints can also be used for DRF.

_Why not use GraphQL for everything?_ - In some one-off cases, a DRF API View is faster and easier to write and does not require or fit into the types graph. In my case, I had a single purpose, data-heavy endpoint that suffered poor performance when processed by GraphQL's type system. I threw together a DRF endpoint that grabs raw data from the DB -> transforms it to a list of dicts -> JSON HTTP Response.

## How to test

I have tested this in a project I'm working on. I could write a sample view and unit test, for instance.