### PR TITLE
upgrade pillow

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -25,7 +25,7 @@ drf-yasg = "==1.20.0"
 django-multiselectfield = "==0.1.12"
 drf-writable-nested = "==0.6.3"
 python-slugify = "==5.0.2"
-Pillow = "==8.3.1"
+Pillow = "==9.0"
 django-currentuser = "==0.5.3"
 drf-nested-routers = "==0.93.3"
 django-anymail = "==8.4"  # https://github.com/anymail/django-anymail


### PR DESCRIPTION
## What this does

Upgrades `Pillow to 9.0` current version `Pillow 8.3.1` does not support python `3.10.x`

- [See this link](https://pillow.readthedocs.io/en/stable/installation.html) 



