### PR TITLE
Pin node version for github actions that use it

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           name: my_project
           path: my_project/
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false
@@ -59,6 +62,9 @@ jobs:
         with:
           name: my_project
           path: my_project/
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install frontend dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,7 +6,7 @@ jobs:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
@@ -27,7 +27,7 @@ jobs:
     needs: Setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: my_project
@@ -57,7 +57,7 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
           name: my_project

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -4,7 +4,7 @@ jobs:
   Setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
       - name: Set app_name for Staging

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -7,7 +7,7 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
@@ -29,7 +29,7 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
@@ -51,7 +51,7 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -62,6 +62,9 @@ jobs:
       - run: |
           config_file="cookiecutter/${{ matrix.fe_type }}_template.yaml"
           pipenv run cookiecutter . --config-file $config_file --no-input -f
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -4,7 +4,7 @@ jobs:
   Pytest_CookieCutter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -30,7 +30,7 @@ jobs:
       matrix:
         fe_type: [react, vue]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -6,7 +6,7 @@ jobs:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
         uses: cypress-io/github-action@v4
         with:
@@ -24,7 +24,7 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
         uses: cypress-io/github-action@v4
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -4,7 +4,7 @@ jobs:
   Black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
@@ -15,7 +15,7 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:
@@ -26,7 +26,7 @@ jobs:
   ESLint_and_Prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: 16

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: pipx install pipenv
       - uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
## What this does

When Github Actions run they run in a container (ish) provided by Github. Usually Node 16 is available in that environment, but not always.
This PR ensures that the expected version is present for jobs that need node.