### PR TITLE
Favicon instructions use wrong URL

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/vue3/README.md
+++ b/{{cookiecutter.project_slug}}/clients/vue3/README.md
@@ -2,10 +2,10 @@
 
 ## Favicon Setup
 
-The Django app is already configured to serve favorite icons for all browsers and platforms (include, for example, apple-icons and android-icons at various sizes). By default, this icon is the vue/react logo.
+The Django app is already configured to serve favorite icons for all browsers and platforms (include, for example, apple-icons and android-icons at various sizes). By default, this icon is the TN logo.
 
 **_Note your image must be a square otherwise a white bg will appear because the file is cropped if it is not a square go to [iloveimg.com](https://www.iloveimg.com/resize-image) and resize it._**
-Visit [realfavicongenerator.net](https://realfavicongenerator.net/) and upload a high resolution, square version of the image you would like to use as the favicon for this app.
+Visit [favicon-generator.org](https://www.favicon-generator.org/) and upload a high resolution, square version of the image you would like to use as the favicon for this app.
 
 Download the ZIP file of icons that the site generates for you and paste them in the `client/public/static/favicons/` directory.
 


### PR DESCRIPTION
## What this does

Docs for updating the favicon point to a website that doesn't create favicons the way we are expecting them. Switched the docs to point to the real one we had been using. 
