### PR TITLE
remove makemigs from proc

### DIFF
--- a/{{cookiecutter.project_slug}}/Procfile
+++ b/{{cookiecutter.project_slug}}/Procfile
@@ -14,6 +14,6 @@ web: gunicorn {{ cookiecutter.project_slug }}.wsgi --chdir=server --log-file -
 #   3. Up-to-date build numbers shown in app (ideally auto-generated at build-and-deploy time)
 #
 # Comment the line below to disable migrations automatically after a Heroku push.
-release: python server/manage.py makemigrations --noinput && python server/manage.py migrate --noinput
+release: python server/manage.py migrate --noinput
 
 


### PR DESCRIPTION
## What this does

Remove the command to make migrations from the procfile.
This causes a big problem, firstly it creates a new migration file if the dev forgot to create the migrations (this can happen when following TDD because migrations are not needed for the test db) meaning the code base on heroku is not the same as the code base in our github. If this does occur then the migration is run on the heroku server, added to the db and then replaced when the dev eventually realizes their error and pushes up the migration. Not only that but if there were any intermediary migrations before this mess up then we can also have issues and conflicts with the migration tree. 

In response to this: 
>Ed
:business_cat:  [1 day ago](https://thinknimble.slack.com/archives/C02LK1X84N7/p1682447231120349?thread_ts=1682446202.682839&cid=C02LK1X84N7)
I think I’ve seen situations where a 3rd party library needed makemigrations run since they didn’t include them. But honestly I’d rather that be an error we get and address it then

This is fine if you install a 3rd party lib you should be running makemigrations yourself in fact Django will tell you that you need to do that!


- 

## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
