### PR TITLE
Small improvements: init_db.sh, README, and logging

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/pull_request_template.md
+++ b/{{cookiecutter.project_slug}}/.github/pull_request_template.md
@@ -19,6 +19,8 @@ Add any notes for changes needed when deployed. I.e. API keys, environment varia
 Add user steps to achieve desired functionality for this feature.
 
 ## Django Admin 
-user: admin@thinknimble.com
-password: !!!DJANGO_SECRET_KEY!!!
+| user | password | has admin | notes |
+| --- | --- | --- | --- |
+| `admin@thinknimble.com` | !!!DJANGO_SECRET_KEY!!! | :white_check_mark: | |
+| `cypress@example.com` | !!!DJANGO_SECRET_KEY!!! | :x: | Only use for automated E2E testing |
 

--- a/{{cookiecutter.project_slug}}/scripts/init-db.sh
+++ b/{{cookiecutter.project_slug}}/scripts/init-db.sh
@@ -55,11 +55,21 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 fi
 
 echo "##### postresql is installed"
+
+echo "##### Dropping the DB if it already exists"
+dropdb $db_name
+DROPDB_SUCCESS=$?
+
 echo "##### Creating database: $db_name"
 sudo -u $sudo_p_user createdb $db_name
-echo "##### Creating user: $db_user"
-sudo -u $sudo_p_user psql -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
+
+if [ $DROPDB_SUCCESS != 0 ] ; then
+    # db didn't exist. Assume users and permissions are missing
+    echo "##### Creating user: $db_user"
+    sudo -u $sudo_p_user psql -c "CREATE USER $db_user WITH PASSWORD '$db_pass';"
+    echo "##### Giving user permission to create the test db"
+    sudo -u $sudo_p_user psql -c "ALTER USER $db_user CREATEDB;"
+fi
+
 echo "##### Giving user permission to the database"
 sudo -u $sudo_p_user psql -c "GRANT ALL PRIVILEGES ON DATABASE $db_name to $db_user;"
-echo "##### Giving user permission to create the test db"
-sudo -u $sudo_p_user psql -c "ALTER USER $db_user CREATEDB;"

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/create_test_data.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/create_test_data.py
@@ -1,12 +1,17 @@
+import logging
+
 from decouple import config
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
     help = "Create test data to seed database in dev and staging environments"
 
     def handle(self, *args, **kwargs):
+        logger.info(f"Starting management command {__name__}")
         superuser_password = config("DJANGO_SUPERUSER_PASSWORD")
         cypress_password = config("CYPRESS_TEST_USER_PASS")
         get_user_model().objects.create_superuser(
@@ -15,3 +20,4 @@ class Command(BaseCommand):
         get_user_model().objects.create_user(
             email="cypress@example.com", password=cypress_password, first_name="Cypress", last_name="E2E_test"
         )
+        logger.info(f"Finished management command {__name__}")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/models.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/models.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.contrib.auth.tokens import default_token_generator
@@ -8,6 +10,8 @@ from rest_framework.authtoken.models import Token
 
 from {{ cookiecutter.project_slug }}.common.models import AbstractBaseModel
 from {{ cookiecutter.project_slug }}.utils.sites import get_site_url
+
+logger = logging.getLogger(__name__)
 
 
 class UserManager(BaseUserManager):
@@ -29,12 +33,14 @@ class UserManager(BaseUserManager):
 
     def create_user(self, email, password=None, **extra_fields):
         """Create and save a regular User with the given email and password."""
+        logger.info(f"New user: {email}")
         extra_fields.setdefault("is_staff", False)
         extra_fields.setdefault("is_superuser", False)
         return self._create_user(email, password, **extra_fields)
 
     def create_superuser(self, email, password, **extra_fields):
         """Create a superuser with the given email and password."""
+        logger.warning(f"Creating superuser: {email}")
         extra_fields["is_staff"] = True
         extra_fields["is_superuser"] = True
         extra_fields["has_reset_password"] = True

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -293,7 +293,7 @@ if config("USE_AWS_STORAGE", cast=bool, default=False) and not IS_REVIEW_APP:
     AWS_STORAGE_BUCKET_NAME = config("AWS_STORAGE_BUCKET_NAME")
     AWS_SECRET_ACCESS_KEY = config("AWS_SECRET_ACCESS_KEY")
     AWS_S3_CUSTOM_DOMAIN = AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com"
-    AWS_LOCATION = config("AWS_LOCATION", default="")  # production, staging, etc
+    AWS_LOCATION = config("AWS_LOCATION")  # production, staging, etc
     AWS_S3_REGION_NAME = config("AWS_S3_REGION_NAME")
 
     aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -359,6 +359,7 @@ LOGGING = {
             "level": "INFO",
             "filters": ["require_debug_true"],
             "class": "logging.StreamHandler",
+            "formatter": "verbose",
         },
     },
     "loggers": {

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -293,7 +293,7 @@ if config("USE_AWS_STORAGE", cast=bool, default=False) and not IS_REVIEW_APP:
     AWS_STORAGE_BUCKET_NAME = config("AWS_STORAGE_BUCKET_NAME")
     AWS_SECRET_ACCESS_KEY = config("AWS_SECRET_ACCESS_KEY")
     AWS_S3_CUSTOM_DOMAIN = AWS_STORAGE_BUCKET_NAME + ".s3.amazonaws.com"
-    AWS_LOCATION = config("AWS_LOCATION", default="")
+    AWS_LOCATION = config("AWS_LOCATION", default="")  # production, staging, etc
     AWS_S3_REGION_NAME = config("AWS_S3_REGION_NAME")
 
     aws_s3_domain = AWS_S3_CUSTOM_DOMAIN or f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"


### PR DESCRIPTION
## What this does

A bunch of small quality of life improvements (see list below)

## Checklist
- [x] The `init_db.sh` script will now delete an existing DB if it finds one
- [x] `README` now has a default table of auto-created accounts, creds, what access they have, etc.
- [x] Verbose logging turned on by default so log messages will tell you the file and line number a message came from
- [x] Added default/example log messages to a couple of places
