### PR TITLE
Added ENABLE_EMAILS env var to .env.example.

### DIFF
--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -136,6 +136,7 @@ REDIS_URL='redis://127.0.0.1:6379/1'
 #
 {%- if cookiecutter.mail_service == 'Mailgun' %}
 # Mailgun
+ENABLE_EMAILS='False'
 MAILGUN_API_KEY=''
 MAILGUN_DOMAIN=''
 MAILGUN_API_URL=''


### PR DESCRIPTION
## What this does

Resolves issue #186 by adding the ENABLE_EMAILS env var to [.env.example](https://github.com/thinknimble/tn-spa-bootstrapper/blob/ca60c3534a1480c8edc28835c0ed7a3d06942228/%7B%7Bcookiecutter.project_slug%7D%7D/.env.example).

## Checklist
- [x] Add the ENABLE_EMAILS env var to [.env.example](https://github.com/thinknimble/tn-spa-bootstrapper/blob/ca60c3534a1480c8edc28835c0ed7a3d06942228/%7B%7Bcookiecutter.project_slug%7D%7D/.env.example)


## How to test

Check the [.env.example](https://github.com/thinknimble/tn-spa-bootstrapper/blob/ca60c3534a1480c8edc28835c0ed7a3d06942228/%7B%7Bcookiecutter.project_slug%7D%7D/.env.example) file.
