### PR TITLE
Feature: Add an autocomplete list filter for foreign key in Django admin

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/static/common/autocompleteFilter.js
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/static/common/autocompleteFilter.js
@@ -1,0 +1,23 @@
+'use strict';
+
+
+function applyFilter(event, parameterName) {
+  const prefix = getPrefixFromElement(event.target);
+  const value = document.getElementById(`${prefix}-${parameterName}`).value;
+  const newSearchParam = `${parameterName}=${value}`;
+  const stringToReplace = new RegExp(`([\\?|&])${parameterName}=[^&]*(&)?`);
+
+  if (stringToReplace.test(window.location.search)) {
+    // $1 will be the preceding question mark or ampersand and $2 the ampersand after if any
+    window.location.search = window.location.search.replace(stringToReplace, `$1${newSearchParam}$2`);
+  } else {
+    const joiner = window.location.search.includes("?") ? "&" : "?";
+    window.location.search += `${joiner}${newSearchParam}`;
+  }
+}
+
+
+function getPrefixFromElement(element) {
+  if (!element) return;
+  return element.getAttribute("data-input-filter-prefix") || getPrefixFromElement(element.parentElement);
+}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/templates/common/autocomplete_filter.html
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/templates/common/autocomplete_filter.html
@@ -1,0 +1,28 @@
+{%- raw -%}
+{% load i18n %}
+{% load static %}
+
+<div data-filter-title="{{ title }}">
+  {% block summary %}
+  <h3>
+    {% blocktranslate with filter_title=title %} By {{ filter_title }} {% endblocktranslate %}
+  </h3>
+  {% endblock %}
+  <ul>
+    <select
+      class="admin-autocomplete"
+      id="autocomplete-filter-{{ spec.parameter_name }}"
+      onchange="applyFilter(event, '{{ spec.parameter_name }}');"
+      name="{{ spec.parameter_name }}"
+      data-input-filter-prefix="autocomplete-filter"
+      {% for key, value in spec.autocomplete_configuration.items %}
+        {{ key }}="{{ value }}"
+      {% endfor %}
+    >
+      {% if spec.value %}
+        <option value={{ spec.value }} selected>{{ spec.value_title }}</option>
+      {% endif %}
+    </select>
+  </ul>
+</div>
+{%- endraw -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/templates/common/filters.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/templates/common/filters.py
@@ -1,0 +1,79 @@
+from typing import Dict
+
+from django.conf import settings
+from django.contrib import admin
+from django.contrib.admin.filters import RelatedFieldListFilter
+from django.contrib.admin.options import IncorrectLookupParameters
+from django.contrib.admin.widgets import SELECT2_TRANSLATIONS, get_language
+from django.db.models import Model, QuerySet
+from django.db.models.fields.related import ForeignKey
+from django.http import HttpRequest
+from django.urls import reverse
+
+
+class AutocompleteFilter(RelatedFieldListFilter):
+    template = "common/autocomplete_filter.html"
+    url_name = "%s:autocomplete"
+    parameter_name = None
+
+    def __init__(
+        self, field: ForeignKey, request: HttpRequest, params: Dict[str, str], model: Model, model_admin: admin.ModelAdmin, field_path: str
+    ):
+        self.parameter_name = self.parameter_name or field_path
+        super().__init__(field, request, params, model, model_admin, field_path)
+        self.admin_site = model_admin.admin_site
+        self.value = params.pop(self.parameter_name, None)
+        self.value_title = field.related_model.objects.get(pk=self.value) if self.value else None
+        self.autocomplete_configuration = {
+            "data-ajax--cache": "true",
+            "data-ajax--delay": 250,
+            "data-ajax--type": "GET",
+            "data-ajax--url": self.get_url(),
+            "data-app-label": field.model._meta.app_label,
+            "data-model-name": field.model._meta.model_name,
+            "data-field-name": field.name,
+            "data-theme": "admin-autocomplete",
+            "data-allow-clear": "true",
+            "data-placeholder": "",  # Allows clearing of the input.
+            "lang": SELECT2_TRANSLATIONS.get(get_language()),
+        }
+
+    def get_url(self):
+        return reverse(self.url_name % self.admin_site.name)
+
+    def queryset(self, request: HttpRequest, queryset: QuerySet) -> QuerySet:
+        try:
+            queryset = super().queryset(request, queryset)
+        except IncorrectLookupParameters as e:
+            # Ignore exception for providing empty query parameter and just return unfiltered queryset.
+            if "is not a valid UUID." in str(e):
+                pass
+        if self.value:
+            queryset = queryset.filter(**{self.parameter_name: self.value})
+        return queryset
+
+
+class AutocompleteAdminMedia:
+    i18n_name = SELECT2_TRANSLATIONS.get(get_language())
+    i18n_file = ("admin/js/vendor/select2/i18n/%s.js" % i18n_name,) if i18n_name else ()
+    extra = "" if settings.DEBUG else ".min"
+
+    js = (
+        (
+            "admin/js/vendor/jquery/jquery%s.js" % extra,
+            "admin/js/vendor/select2/select2.full%s.js" % extra,
+        )
+        + i18n_file
+        + (
+            "admin/js/jquery.init.js",
+            "admin/js/autocomplete.js",
+            # Unlike all previous entries, this is a custom JS file from this project rather than a Django one!
+            "common/autocompleteFilter.js"
+        )
+    )
+    css = {
+        "screen": (
+            "admin/css/vendor/select2/select2%s.css" % extra,
+            "admin/css/autocomplete.css",
+        )
+    }


### PR DESCRIPTION
## What this does

Django's default way of rendering admin list filters for foreign keys just sucks!
If your related model has many rows in the database, it can start slowing your admin site down really quickly, even making it unusable due to timeouts.

This PR intends to provide an easy-to-use out-of-the-box replacement: A select2 widget similar to the behaviour you can set for the detail change view if configured through **autocomplete_fields** attribute.
However, Django still does not provide a select2 widget for the filters. This solution implements a custom filter.


Changes this:

![image](https://github.com/thinknimble/tn-spa-bootstrapper/assets/127348271/b9bdd6ed-0b59-4b6b-b338-bcc94e17628d)


Into this:
![image](https://github.com/thinknimble/tn-spa-bootstrapper/assets/127348271/c04d390b-edd3-4fec-9d8a-8b0ed45e70cb)



## How to test

1. Use cookiecutter to create a project based on this branch: `cookiecutter https://github.com/thinknimble/tn-spa-bootstrapper.git --checkout feat/autocomplete-admin-list-filter`
2. Create a model which has a ForeignKey field, makemigrations and run them.
3. Create an Admin and set up a filter using AutocompleteFilter.
4.  Remember to make your Admin's Media class a subclass of AutocompleteAdminMedia.

## Code examples

**models.py**
```py
class MyModel(AbstractBaseModel):
    user = models.ForeignKey("User", on_delete=models.CASCADE)

    def __str__(self):
        return str(self.user)
```

**admin.py**
```py
from {PROJECT_NAME}.common.templates.common.filters import AutocompleteFilter, AutocompleteAdminMedia


@admin.register(MyModel)
class MyModelAdmin(admin.ModelAdmin):
    list_filter = (("user", AutocompleteFilter), )

    class Media(AutocompleteAdminMedia):
        pass
```
