### PR TITLE
Version pin Cypress Github Action to 16

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -6,6 +6,9 @@ jobs:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - uses: actions/checkout@v3
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
         uses: cypress-io/github-action@v4


### PR DESCRIPTION
## What this does

Pins the node version for the cypress test on chrome to 16
Cypress tests are unstable without this as the Github Action container will use whatever is available. Sometimes that 16, sometimes it's 12. Pinning it forces it to use the one we need.
