### PR TITLE
Update Docker Python to 3.10

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/server/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-buster
+FROM python:3.10-slim-buster
 
 # These environment values help with watching for file changes
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
## What this does

Updates Python to 3.10 to match what the Pipefile expects, this was causing issues since the pipfile.lock is created with 3.10 but then the Docker env was using 3.7

[closes ](https://github.com/thinknimble/tn-spa-bootstrapper/issues/237)

## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
