### PR TITLE
Cypress Chrome Github Action ECONNRESET error

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -27,6 +27,9 @@ jobs:
   Chrome:
     needs: Setup
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -5,6 +5,9 @@ jobs:
   Chrome:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
+    container:
+      image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
+      options: --user 1001
     steps:
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
## What this does

Our Cypress tests running on Chrome started failing for all of our projects.
The error was basically this one:
https://stackoverflow.com/questions/71294032/cypress-econnreset

The important thing to remember with Github Actions is that we don't have full control over the container that the action runs in. If you write a simple Github Action, it may work for a while, but eventually you might run into errors because the wrong version of node or python is installed and so something behaves oddly.

This is the reason why we pin version using `python-version` and `node-version` depending on what the action needs.

Now I don't fully know what the issue was here. Most users with this issue have found it to be a problem with their local machine. I'm sure with enough digging we could figure out what was actually the issue and maybe version pin that specific thing....but I took the sledge hammer approach.

We already needed to use a Cypress provide docker container for Firefox since that browser has well documented issues when running in Github Actions.

Running in a container controls for everything and so that was the quick/easy solution here.

It also means the Firefox and Chrome now run the same exact way.