### PR TITLE
Update gitignore to correctly exclude multiple env files

### DIFF
--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -75,11 +75,8 @@ target/
 celerybeat-schedule
 
 # Environments
-.env
-.venv
-env/
-venv/
-ENV/
+.env*
+!.env.example
 
 # Rope project settings
 .ropeproject


### PR DESCRIPTION
This change resolves issue #251 by updating the .gitignore file. The change ensures that multiple env files are correctly excluded.

Signed-off-by: John Park <shinopark24@gmail.com>