### PR TITLE
redirect urls without slash

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
@@ -41,6 +41,5 @@ if settings.DEBUG:  # pragma: no cover
     urlpatterns += [path("api-auth/", include("rest_framework.urls"))]
 
 urlpatterns += [
-    path("", common_views.index),
     re_path(r".*/$", common_views.index),
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
@@ -41,5 +41,6 @@ if settings.DEBUG:  # pragma: no cover
     urlpatterns += [path("api-auth/", include("rest_framework.urls"))]
 
 urlpatterns += [
-    re_path(r".*", common_views.index),
+    path("", common_views.index),
+    re_path(r".*/$", common_views.index),
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
@@ -41,5 +41,6 @@ if settings.DEBUG:  # pragma: no cover
     urlpatterns += [path("api-auth/", include("rest_framework.urls"))]
 
 urlpatterns += [
+    path("", common_views.index),
     re_path(r".*/$", common_views.index),
 ]


### PR DESCRIPTION
## What this does

See [link](https://docs.djangoproject.com/en/5.0/ref/middleware/#django.middleware.common.CommonMiddleware) for details, but for convenience:

> If [APPEND_SLASH](https://docs.djangoproject.com/en/5.0/ref/settings/#std-setting-APPEND_SLASH) is True and the initial URL doesn’t end with a slash, and it is not found in the URLconf, then a new URL is formed by appending a slash at the end. If this new URL is found in the URLconf, then Django redirects the request to this new URL. Otherwise, the initial URL is processed as usual.

> For example, foo.com/bar will be redirected to foo.com/bar/ if you don’t have a valid URL pattern for foo.com/bar but do have a valid pattern for foo.com/bar/.


`APPEND_SLASH` is enabled by default but we have a catch all regex url matcher which kind of cancels it out, since it matches everything and doesn't allow the code that would add the slash append happen to run. I made it more specific  (`*./$`, i.e. all urls that specifically end in a slash) so that normal api routes can be redirected properly and I can stop tearing my hair out every time I forget a slash and instead of hitting the api it redirects to the normal `index.html` and looks like a 200.

There's two lines because I preserved the existing functionality of empty url going to index if that's important for some reason. Alternatively you can remove that first new line and just going to empty url gets you a 404 since it doesn't match anything. Everything else stays identical to previous functionality.


## How to test

Add user steps to achieve desired functionality for this feature.
