### PR TITLE
Fix pytest project slug reference

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests.py
@@ -102,7 +102,7 @@ class TestPreviewTemplateView:
 
     @override_settings(DEBUG=True)
     def test_enabled_if_debug(self, client):
-        with mock.patch("my_project.core.views.render", return_value=Response()) as mocked_render:
+        with mock.patch("{{ cookiecutter.project_slug }}.core.views.render", return_value=Response()) as mocked_render:
             client.get(f"{self.url}?template=core/index-placeholder.html")
         assert mocked_render.call_count == 1
 


### PR DESCRIPTION
## What this does

Pytests fail on creation of app due to missing project_slug variable

## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
