### PR TITLE
Clients: Fix - CSRF Token issues

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/services/user/api.ts
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/services/user/api.ts
@@ -36,6 +36,10 @@ const resetPassword = createCustomServiceCall(
   },
 )
 
+const logout = createCustomServiceCall(async ({ client }) => {
+  return client.post(`/logout/`)
+})
+
 export const userApi = createApi(
   {
     client: axiosInstance,
@@ -45,5 +49,5 @@ export const userApi = createApi(
       entity: userShape,
     },
   },
-  { login, requestPasswordResetCode, resetPassword },
+  { login, requestPasswordResetCode, resetPassword ,logout },
 )

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/stores/auth.ts
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/stores/auth.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
-import { UserShape as User } from '@services/user/'
+import { UserShape as User, userApi } from '@services/user/'
 import { queryClient } from '@utils/query-client'
 import { createSelectors } from '@stores/utils'
 
@@ -91,7 +91,8 @@ export const useAuth = createSelectors(
   ),
 )
 
-export const logout = () => {
+export const logout = async() => {
+  await userApi.csc.logout()
   useAuth.getState().actions.clearAuth()
   queryClient.invalidateQueries({queryKey: ['user']})
 }

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/services/user/api.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/services/user/api.ts
@@ -3,15 +3,16 @@ import { z } from 'zod'
 import { axiosInstance } from '../axios-instance'
 import { userShape, forgotPasswordShape, userCreateShape, loginShape, LoginShape } from './models'
 
-export const login = async (input: LoginShape) => {
-  const { utils } = createApiUtils({
+const login = createCustomServiceCall(
+  {
     inputShape: loginShape,
     outputShape: userShape,
-    name: login.name,
-  })
-  const res = await axiosInstance.post('/login/', utils.toApi(input))
-  return utils.fromApi(res.data)
-}
+  },
+  async ({ client, input, utils }) => {
+    const res = await client.post('/login/', utils.toApi(input))
+    return utils.fromApi(res.data)
+  },
+)
 
 const requestPasswordReset = createCustomServiceCall(
   {
@@ -33,6 +34,10 @@ const resetPassword = createCustomServiceCall(
   },
 )
 
+const logout = createCustomServiceCall(async ({ client }) => {
+  return client.post(`/logout/`)
+})
+
 export const userApi = createApi(
   {
     client: axiosInstance,
@@ -42,5 +47,5 @@ export const userApi = createApi(
       entity: userShape,
     },
   },
-  { requestPasswordReset, resetPassword },
+  { login, requestPasswordReset, resetPassword ,logout },
 )

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/stores/auth.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/stores/auth.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import { User } from '../services/user'
+import { User, userApi } from '../services/user'
 import { queryClient } from '../utils/query-client'
 import { createSelectors } from './utils'
 
@@ -86,7 +86,8 @@ export const useAuth = createSelectors(
   ),
 )
 
-export const logout = () => {
+export const logout = async() => {
+  await userApi.csc.logout()
   useAuth.getState().actions.clearAuth()
   queryClient.invalidateQueries({ queryKey: ['user'] })
 }

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/components/NavBar.vue
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/components/NavBar.vue
@@ -131,6 +131,7 @@
 </template>
 
 <script>
+import { userApi } from '@/services/users'
 import { computed, ref } from 'vue'
 
 import { useRouter } from 'vue-router'
@@ -143,7 +144,8 @@ export default {
     let mobileMenuOpen = ref(false)
     let profileMenuOpen = ref(false)
 
-    function logout() {
+    async function logout() {
+      await userApi.csc.logout()
       profileMenuOpen.value = false
       mobileMenuOpen.value = false
       store.dispatch('setUser', null)

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/services/users/api.js
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/services/users/api.js
@@ -47,5 +47,5 @@ export const userApi = createApi(
       entity: userShape,
     },
   },
-  { login, requestPasswordReset, resetPassword , logout },
+  { login, requestPasswordReset, resetPassword, logout },
 )

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/services/users/api.js
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/services/users/api.js
@@ -34,6 +34,10 @@ const resetPassword = createCustomServiceCall(
   },
 )
 
+const logout = createCustomServiceCall(async ({ client }) => {
+  return client.post(`/logout/`)
+})
+
 export const userApi = createApi(
   {
     client: axiosInstance,
@@ -43,5 +47,5 @@ export const userApi = createApi(
       entity: userShape,
     },
   },
-  { login, requestPasswordReset, resetPassword },
+  { login, requestPasswordReset, resetPassword , logout },
 )

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
@@ -4,7 +4,7 @@
       Welcome to {{ cookiecutter.project_name }}!
     </h1>
     <p class="mt-6 text-lg leading-8 text-gray-600">
-      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is 
+      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is
       the first thing that users will see on the home page.
     </p>
     <div class="mt-10 flex items-center justify-center gap-x-6">

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
@@ -1,8 +1,11 @@
 <template>
   <div class="mx-auto flex min-h-full max-w-2xl flex-col items-center px-6 py-20 sm:py-48 lg:px-8">
-    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Welcome to {{ cookiecutter.project_name }}!</h1>
+    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
+      Welcome to {{ cookiecutter.project_name }}!
+    </h1>
     <p class="mt-6 text-lg leading-8 text-gray-600">
-      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is the first thing that users will see on the home page.
+      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is 
+      the first thing that users will see on the home page.
     </p>
     <div class="mt-10 flex items-center justify-center gap-x-6">
       <router-link :to="{ name: 'Dashboard' }" class="btn--accent">Get started</router-link>

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/src/views/Home.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="mx-auto flex min-h-full max-w-2xl flex-col items-center px-6 py-20 sm:py-48 lg:px-8">
-    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">
-      Welcome to {{ cookiecutter.project_name }}!
-    </h1>
+    <h1 class="text-4xl font-bold tracking-tight text-gray-900 sm:text-6xl">Welcome to {{ cookiecutter.project_name }}!</h1>
     <p class="mt-6 text-lg leading-8 text-gray-600">
-      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is
-      the first thing that users will see on the home page.
+      Here's some information about {{ cookiecutter.project_name }}. Please update and expand on this text. This text is the first thing that users will see on the home page.
     </p>
     <div class="mt-10 flex items-center justify-center gap-x-6">
       <router-link :to="{ name: 'Dashboard' }" class="btn--accent">Get started</router-link>


### PR DESCRIPTION
## What this does

- Add call to `/logout` to clear cookies in browser (added to mobile as well but  I don't think that changes anything there)

## What fixes
We had this issue for some time where if you 
Log In > Log Out > Sign up
There was a `sessionid` cookie that didn't get cleaned up on logout. This cookie was httpOnly which didn't allow the FE js to access and delete it. This needed to be done by the backend so for that we needed to call the `/logout` endpoint which is what we're doing in this PR.

## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
