### PR TITLE
Version bump Github Actions

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -6,9 +6,9 @@ jobs:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           # Can't use cache because of https://github.com/actions/cache/issues/319
@@ -19,7 +19,7 @@ jobs:
           config_file=$(./scripts/vue_or_react.sh)
           pipenv run cookiecutter . --config-file $config_file --no-input -f
           cat $config_file
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: my_project
           path: my_project/
@@ -31,12 +31,12 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: my_project
           path: my_project/
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install frontend dependencies
@@ -61,12 +61,12 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: my_project
           path: my_project/
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: Install frontend dependencies
@@ -91,7 +91,7 @@ jobs:
     outputs:
       BUILD_MOBILE_APP: ${{ steps.checkdiff.outputs.BUILD_MOBILE_APP }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 5
         name: check diff
@@ -120,17 +120,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: getprnumber
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: my_project
           path: my_project/
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -45,7 +45,7 @@ jobs:
         working-directory: ./my_project/client
         run: npm install
       - name: Run against ${{ github.event.deployment_status.environment_url }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: my_project/client
           browser: chrome
@@ -75,7 +75,7 @@ jobs:
         working-directory: ./my_project/client
         run: npm install
       - name: Run against ${{ github.event.deployment_status.environment_url }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: my_project/client
           browser: firefox
@@ -106,7 +106,7 @@ jobs:
     needs: configuremobile
     if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0
     steps:
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@master
         id: findPr
       - name: Set name for PR
         if: success() && steps.findPr.outputs.number

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@master
         id: findPr
       - name: Set app_name for Staging
         run: echo "APP_NAME=tn-spa-bootstrapper-staging" >> $GITHUB_ENV

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -4,7 +4,7 @@ jobs:
   Setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: jwalton/gh-find-current-pr@v1
         id: findPr
       - name: Set app_name for Staging

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -5,9 +5,9 @@ jobs:
   Black_bootstrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -17,9 +17,9 @@ jobs:
   flake8_bootstrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -32,9 +32,9 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -54,9 +54,9 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -76,9 +76,9 @@ jobs:
         fe_type: [react, vue]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -87,7 +87,7 @@ jobs:
       - run: |
           config_file="cookiecutter/${{ matrix.fe_type }}_template.yaml"
           pipenv run cookiecutter . --config-file $config_file --no-input -f
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: 📦 Install client dependencies
@@ -102,9 +102,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -114,7 +114,7 @@ jobs:
           config_file="cookiecutter/rn_template.yaml"
           pipenv run cookiecutter . --config-file $config_file --no-input -f
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: 📦 Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,9 +5,9 @@ jobs:
   Pytest_bootstrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -31,9 +31,9 @@ jobs:
       matrix:
         fe_type: [react, vue]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -14,7 +14,7 @@ jobs:
           node-version: 16
       - uses: actions/checkout@v4
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: client
           browser: chrome
@@ -32,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
-        uses: cypress-io/github-action@v4
+        uses: cypress-io/github-action@v6
         with:
           working-directory: client
           browser: firefox

--- a/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/cypress.yml
@@ -9,10 +9,10 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
         uses: cypress-io/github-action@v4
         with:
@@ -30,7 +30,7 @@ jobs:
       image: cypress/browsers:node16.14.2-slim-chrome103-ff102  # https://github.com/cypress-io/cypress-docker-images/tree/master/browsers
       options: --user 1001
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Run against {{ "${{ github.event.deployment_status.environment_url }}" }}
         uses: cypress-io/github-action@v4
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
@@ -8,15 +8,15 @@ jobs:
 
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: {{ "${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}" }}
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: 18.x
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
@@ -9,7 +9,7 @@ jobs:
     outputs:
         BUILD_MOBILE_APP: {{ "${{ steps.checkdiff.outputs.BUILD_MOBILE_APP }}" }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 2
         name: check diff
@@ -31,10 +31,10 @@ jobs:
     if: needs.setup.outputs.BUILD_MOBILE_APP != 0
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: yarn

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
@@ -41,7 +41,7 @@ jobs:
           cache-dependency-path: ./mobile/yarn.lock
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-pr-teardown.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-pr-teardown.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-pr-teardown.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-pr-teardown.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: 🏗 Setup Expo and EAS
         uses: expo/expo-github-action@v7

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
@@ -4,7 +4,7 @@ jobs:
   setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: jwalton/gh-find-current-pr@v1
+      - uses: jwalton/gh-find-current-pr@master
         id: findPr
       - name: Set name for PR
         if: success() && steps.findPr.outputs.number
@@ -33,7 +33,7 @@ jobs:
           node-version: 18.x
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
@@ -20,15 +20,15 @@ jobs:
     needs: setup
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: {{ "${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}" }}
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: ./mobile/yarn.lock
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: yarn

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
@@ -20,7 +20,7 @@ jobs:
           cache-dependency-path: ./mobile/yarn.lock
 
       - name: 🏗 Setup Expo and EAS
-        uses: expo/expo-github-action@v7
+        uses: expo/expo-github-action@v8
         with:
           expo-version: latest
           eas-version: latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
           cache: yarn

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -46,8 +46,6 @@ jobs:
       - name: 🎨 Prettier
         working-directory: ./client
         run: npm run format:check
-      - name: Run ESLint
-        working-directory: ./client
 {%- endif %}
 {%- if cookiecutter.include_mobile == 'y' %}
   Lint_Mobile:

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
       - name: 📦 Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -4,9 +4,9 @@ jobs:
   Black:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -15,9 +15,9 @@ jobs:
   flake8:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'
@@ -27,8 +27,8 @@ jobs:
   Lint_Web:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
       - name: 📦 Install dependencies
@@ -54,9 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 🏗 Setup repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 🏗 Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: 18.x
       - name: 📦 Install dependencies

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -17,9 +17,9 @@ jobs:
         # needed because the postgres container does not provide a healthcheck
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: pipx install pipenv
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           cache: 'pipenv'

--- a/{{cookiecutter.project_slug}}/compose/client/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine
+FROM node:18-alpine
 
 WORKDIR /app/client
 


### PR DESCRIPTION
## What this does

Github Actions are throwing warnings about using actions that are on node12 or node16.
Taking the opportunity to version bump all of the officially supported actions.


## How to test

Add user steps to achieve desired functionality for this feature.
