### PR TITLE
new way of env vars

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/.env.example
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/.env.example
@@ -1,7 +1,6 @@
 # These variables are available only when running locally
+# env vars are picked up automatically from eas.json in `development_local` profile 
+# You can use this file to override them by prefixing with `EXPO_PUBLIC_`
 
 # BACKEND_SERVER_URL="https://{{ cookiecutter.project_slug }}-staging.herokuapp.com"
-# ROLLBAR_ACCESS_TOKEN=''
-# SENTRY_PROJECT_NAME=''
-# SENTRY_DSN=""
-# SENTRY_AUTH_TOKEN=""
+

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/.env.example
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/.env.example
@@ -2,5 +2,5 @@
 # env vars are picked up automatically from eas.json in `development_local` profile 
 # You can use this file to override them by prefixing with `EXPO_PUBLIC_`
 
-# BACKEND_SERVER_URL="https://{{ cookiecutter.project_slug }}-staging.herokuapp.com"
+# EXPO_PUBLIC_BACKEND_SERVER_URL="https://{{ cookiecutter.project_slug }}-staging.herokuapp.com"
 

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/Config.js
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/Config.js
@@ -1,5 +1,4 @@
 import Logger from './logger'
-import { BACKEND_SERVER_URL, ROLLBAR_ACCESS_TOKEN, SENTRY_DSN } from '@env'
 import { Platform } from 'react-native'
 import Constants from 'expo-constants'
 
@@ -19,7 +18,7 @@ const ENV = () => {
     }
   }
   return {
-    backendServerUrl: BACKEND_SERVER_URL,
+    backendServerUrl: BACKEND_SERVER_URL ?? backendServerUrl,
     logger: new Logger(rollbarToken).logger,
     sentryDSN: SENTRY_DSN,
   }

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/babel.config.js
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/babel.config.js
@@ -5,7 +5,6 @@ module.exports = function (api) {
     plugins: [
       'react-native-reanimated/plugin',
       'nativewind/babel',
-      'module:react-native-dotenv',
       [
         'module-resolver',
         {

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -61,7 +61,6 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.73.4",
-    "react-native-dotenv": "^3.4.8",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-pager-view": "6.2.3",
     "react-native-reanimated": "~3.6.2",


### PR DESCRIPTION
## What this does

Since expo SDK 49 we can bring env vars in a uniform manner using the default eas.json, we can also override these variables with variables from the .env.example (eg when working against a local ngrok backend) by prefixing the env variable with `EXPO_PUBLIC_`

Edit (damian)
Source:
[Reading environment variables from .env files](https://docs.expo.dev/guides/environment-variables/#reading-environment-variables-from-env-files)

This is convenient :
> Variables can be updated as you edit your code without restarting the Expo CLI


## ‼️ important if someone wants to edit this code: 
> `Alternative versions of the expression are not supported. For example, process.env['EXPO_PUBLIC_KEY'] or const {EXPO_PUBLIC_X} = process.env is invalid and will not be inlined.`


## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
