### PR TITLE
Fix test settings so the built in `test_password_reset` passes

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/test_settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/test_settings.py
@@ -2,6 +2,10 @@ from decouple import config
 
 from {{ cookiecutter.project_slug }}.settings import *  # noqa
 
+# Override staticfiles setting to avoid cache issues with whitenoise Manifest staticfiles storage
+# See: https://stackoverflow.com/a/69123932
+STATICFILES_STORAGE = "whitenoise.storage.CompressedStaticFilesStorage"
+
 MEDIA_URL = "/media/"
 DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
 


### PR DESCRIPTION
## What this does

I've had to fix this on a couple projects. The built-in unit test `test_password_reset` fails locally because Django whitenoise `CompressedManifestStaticFilesStorage` expects logo.png to exist in the manifest. But that only works after `collectstatic` has been called, making this test flaky.

This PR adjusts the `STATICFILES_STORAGE` value in `test_settings.py` so that the whitenoise manifest check is bypassed and so `test_password_reset` will pass.

## How to test

Bootstrap a new project and run unit tests locally. They no longer fail.