### PR TITLE
fix papertrail addons

### DIFF
--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -31,13 +31,13 @@
   },
   "addons": [
     "heroku-postgresql:standard-0",
-    "papertrail:Choklad"
+    "papertrail:choklad"
   ],
   "environments": {
     "review": {
       "addons": [
         "heroku-postgresql:mini",
-        "papertrail:Choklad"
+        "papertrail:choklad"
       ]
     }
   },


### PR DESCRIPTION
## What this does

Apparently this is now case sensitive

<img width="375" alt="image" src="https://github.com/thinknimble/tn-spa-bootstrapper/assets/10493269/bd1fea83-167d-4829-9d94-c40e04d3db28">


## How to test

Note review apps fail to provision without this because it can't find the plan
