### PR TITLE
fix init db script for pg15

### DIFF
--- a/{{cookiecutter.project_slug}}/scripts/init-db.sh
+++ b/{{cookiecutter.project_slug}}/scripts/init-db.sh
@@ -73,3 +73,5 @@ fi
 
 echo "##### Giving user permission to the database"
 sudo -u $sudo_p_user psql -c "GRANT ALL PRIVILEGES ON DATABASE $db_name to $db_user;"
+sudo -u $sudo_p_user psql -c "ALTER DATABASE $db_name OWNER TO $db_user;"
+


### PR DESCRIPTION
## What this does

Postgres 15 changes how create permissions work and makes them more strict: https://www.enterprisedb.com/blog/new-public-schema-permissions-postgresql-15

Essentially, without this extra line any migrations that would create new tables will fall flat

Heroku defaults to creating postgres 15 dbs, so it makes sense for us to stay up to date by developing on pg15 locally as well. Script should not affect existing pg 14 permissions.

