### PR TITLE
minimal updates to accommodate django 4.2.x

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -4,7 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-Django = "==4.0.*"
+Django = "==4.2.*"
 django-extensions = "==3.2.3"
 django-filter = "==2.4.0"
 django-nose = "==1.4.7"
@@ -12,7 +12,7 @@ dj-rest-auth = "*"
 dj-database-url = "==0.5.0"
 django-storages = "==1.11.1"  # https://github.com/jschneier/django-storages
 boto3 = "==1.18.26"
-djangorestframework = "==3.13.*"
+djangorestframework = "==3.15.*"
 gunicorn = "==20.1.0"
 python-decouple = "*"
 pytz = "==2021.1"

--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -4,8 +4,8 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-Django = "==3.2.6"
-django-extensions = "==3.1.3"
+Django = "==4.0.*"
+django-extensions = "==3.2.3"
 django-filter = "==2.4.0"
 django-nose = "==1.4.7"
 dj-rest-auth = "*"
@@ -25,7 +25,7 @@ django-multiselectfield = "==0.1.12"
 drf-writable-nested = "==0.6.3"
 python-slugify = "==5.0.2"
 Pillow = "==9.0"
-django-currentuser = "==0.5.3"
+django-currentuser = "==0.7.0"
 drf-nested-routers = "==0.93.3"
 django-anymail = "==8.4"  # https://github.com/anymail/django-anymail
 rollbar = "==0.16.2"


### PR DESCRIPTION
## What this does

Upgrades Django to Django 4.2.x
Checked python graph to see which packages were breaking, it appears only: 
django-current-user, django-extensions and djangorestframework needed updates

- [x] Django 4.2.x
- [x] django-extensions 3.2.3
- [x] django-current-user 0.7.0
- [x] djangorestframework 3.15.* 


## How to test

Add user steps to achieve desired functionality for this feature.
