### PR TITLE
Upgrade rollbar to version 1.0.0

### DIFF
--- a/{{cookiecutter.project_slug}}/Pipfile
+++ b/{{cookiecutter.project_slug}}/Pipfile
@@ -28,7 +28,7 @@ Pillow = "==9.0"
 django-currentuser = "==0.7.0"
 drf-nested-routers = "==0.93.3"
 django-anymail = "==8.4"  # https://github.com/anymail/django-anymail
-rollbar = "==0.16.2"
+rollbar = "==1.0.0"
 premailer = "*"
 drf-spectacular = "*"
 


### PR DESCRIPTION
## What this does

Rollbar warned me on a project that our library was out of date. This upgrades Rollbar to v1.0.0. I think this should be a risk-free upgrade. Release notes are here: https://github.com/rollbar/pyrollbar/releases/tag/v1.0.0