### PR TITLE
Clients - Mobile - Add better rules for RN eslint to prevent raw text in code

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/.eslintrc.js
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/.eslintrc.js
@@ -11,6 +11,8 @@ module.exports = {
     'prettier/prettier': 'off',
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-unused-vars': 'warn',
+    'react-native/no-raw-text': 2,
+    'react-native/no-unused-styles': 2,
   },
   ignorePatterns: ['tailwind.config.js', 'metro.config.js'],
 }

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/screens/dashboard.tsx
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/screens/dashboard.tsx
@@ -4,7 +4,7 @@ import React from 'react'
 export const DashboardScreen = () => {
   return (
     <MultiPlatformSafeAreaView>
-      <Text>Welcom to the Dash</Text>
+          <Text>Welcome to the Dashboard</Text>
     </MultiPlatformSafeAreaView>
   )
 }


### PR DESCRIPTION
## What this does

Add a rule that errors whenever the linter finds strings not wrapped in `<Text>` component which causes crashes on runtime.

Note that here `eslint-plugin-react-native` was already installed but in the project I was working on this wasn't installed and it is a requirement for this lint rule to work:
```
npm install -D eslint-plugin-react-native
```

## Checklist
- [ ] Todo 1
- [ ] Todo 2
- [ ] Todo 3


## How to test

Add user steps to achieve desired functionality for this feature.
