### PR TITLE
Playwright E2E tests clean-up. Remove all references to Cypress.

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -50,7 +50,7 @@ jobs:
         env:
           NPM_CONFIG_PRODUCTION: false
           PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url }}
-          CYPRESS_TEST_USER_PASS: ${{ secrets.CYPRESS_TEST_USER_PASS }}
+          PLAYWRIGHT_TEST_USER_PASS: ${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -19,6 +19,6 @@ jobs:
         run: npx --prefix ./client playwright test --reporter=html
         env:
           PLAYWRIGHT_TEST_BASE_URL:
-            {{ "${{ github.event.deployment_status.environment_url }}" }}
-          CYPRESS_TEST_USER_PASS:
-            {{ "${{ secrets.CYPRESS_TEST_USER_PASS }}" }}
+            { { "${{ github.event.deployment_status.environment_url }}" } }
+          PLAYWRIGHT_TEST_USER_PASS:
+            { { "${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}" } }

--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -22,7 +22,7 @@
     "DJANGO_SUPERUSER_PASSWORD": {
       "value": "!!!DJANGO_SECRET_KEY!!!"
     },
-    "CYPRESS_TEST_USER_PASS": {
+    "PLAYWRIGHT_TEST_USER_PASS": {
       "value": "!!!DJANGO_SECRET_KEY!!!"
     },
     "SECRET_KEY": {

--- a/{{cookiecutter.project_slug}}/clients/web/react/tests/e2e/specs/login.spec.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/tests/e2e/specs/login.spec.ts
@@ -3,11 +3,11 @@ import { test, expect } from '@playwright/test'
 import dotenv from 'dotenv'
 
 test('Login workflow', async ({ page }) => {
-  expect(process.env.CYPRESS_TEST_USER_PASS).toBeTruthy()
+  expect(process.env.PLAYWRIGHT_TEST_USER_PASS).toBeTruthy()
 
   await page.goto('/log-in')
   await page.getByTestId('email').fill('playwright@thinknimble.com')
-  await page.getByTestId('password').fill(process.env.CYPRESS_TEST_USER_PASS ?? '')
+  await page.getByTestId('password').fill(process.env.PLAYWRIGHT_TEST_USER_PASS ?? '')
   await page.getByTestId('submit').click()
 
   await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()

--- a/{{cookiecutter.project_slug}}/clients/web/vue3/tests/e2e/specs/login.spec.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/vue3/tests/e2e/specs/login.spec.ts
@@ -1,11 +1,11 @@
 import { test, expect } from '@playwright/test'
 
 test('Login workflow', async ({ page }) => {
-  expect(process.env.CYPRESS_TEST_USER_PASS).toBeTruthy()
+  expect(process.env.PLAYWRIGHT_TEST_USER_PASS).toBeTruthy()
 
   await page.goto('/login')
   await page.getByPlaceholder('Enter email...').fill('playwright@thinknimble.com')
-  await page.getByPlaceholder('Enter password...').fill(process.env.CYPRESS_TEST_USER_PASS ?? '')
+  await page.getByPlaceholder('Enter password...').fill(process.env.PLAYWRIGHT_TEST_USER_PASS ?? '')
   await page.getByRole('button', { name: 'Log in' }).click()
 
   await expect(page.getByRole('heading', { name: 'Dashboard' })).toBeVisible()

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -9,7 +9,7 @@
   },
   "cacheDirectories": [
     "client/node_modules",
-    ".cache/Cypress"
+    ".cache/ms-playwright"
   ],
   "dependencies": {}
 }

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/create_test_data.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/create_test_data.py
@@ -13,7 +13,7 @@ class Command(BaseCommand):
     def handle(self, *args, **kwargs):
         logger.info(f"Starting management command {__name__}")
         superuser_password = config("DJANGO_SUPERUSER_PASSWORD")
-        playwright_password = config("CYPRESS_TEST_USER_PASS")
+        playwright_password = config("PLAYWRIGHT_TEST_USER_PASS")
         get_user_model().objects.create_superuser(
             email="admin@thinknimble.com", password=superuser_password, first_name="Admin", last_name="ThinkNimble"
         )


### PR DESCRIPTION
## What this does

Following up on #335 and issue #330 - this removes all references to Cypress. Apps incorporating these changes will need to update their environment variables and repository secrets accordingly.
