### PR TITLE
Improve documentation for Playwright tests.

### DIFF
--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -151,5 +151,5 @@ DEFAULT_FROM_EMAIL='{{ cookiecutter.project_name }} <noreply@{{ cookiecutter.pro
 
 # Testing (NOTE: Heroku and Github Actions will need to have matching values for some of these)
 DJANGO_SUPERUSER_PASSWORD='!!!DJANGO_SECRET_KEY!!!'
-CYPRESS_TEST_USER_PASS='!!!DJANGO_SECRET_KEY!!!'
-CYPRESS_baseUrl='http://localhost:8080'
+PLAYWRIGHT_TEST_USER_PASS='!!!DJANGO_SECRET_KEY!!!'
+PLAYWRIGHT_TEST_BASE_URL='http://localhost:8080'

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -38,5 +38,11 @@ See the [frontend README](client/README.md)
 1. `pipenv run pytest server`
 1. `pipenv run black server`
 1. `pipenv run isort server --diff` (shows you what isort is expecting)
+
+## Frontend E2E Testing with Playwright
+
+1. `cd client`
+1. `npx playwright install` - Installs browser driver
+1. `npx playwright install-deps` - Install system-level dependencies
 1. `npx playwright test`
-1. `npx playwright codegen localhost:8080` (generate your tests through manual testing)
+1. `npx playwright codegen localhost:8080` - Generate your tests through manual testing


### PR DESCRIPTION
## What this does

- Changes some missed references to `CYPRESS` to `PLAYWRIGHT` in `.env.example`, and corrects the env variable name for `PLAYWRIGHT_TEST_BASE_URL`.
- Adds additional installation steps to README.md that are necessary to run Playwright locally