### PR TITLE
Improve user management security

### DIFF
--- a/{{cookiecutter.project_slug}}/.env.example
+++ b/{{cookiecutter.project_slug}}/.env.example
@@ -148,6 +148,8 @@ SMTP_PORT='587'
 SMTP_VALID_TESTING_DOMAINS='thinknimble.com'
 DEFAULT_FROM_EMAIL='{{ cookiecutter.project_name }} <noreply@{{ cookiecutter.project_slug }}.com>'
 {% endif %}
+USE_EMAIL_ALLOWLIST=True
+EMAIL_ALLOWLIST=['admin@thinknimble.com']
 
 # Testing (NOTE: Heroku and Github Actions will need to have matching values for some of these)
 DJANGO_SUPERUSER_PASSWORD='!!!DJANGO_SECRET_KEY!!!'

--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -1,5 +1,6 @@
 {
   "name": "{{ cookiecutter.project_name }}",
+  "stack": "heroku-24",
   "env": {
     "ALLOWED_HOSTS": {
       "value": ".herokuapp.com"
@@ -27,6 +28,12 @@
     },
     "SECRET_KEY": {
       "generator": "secret"
+    },
+    "USE_EMAIL_ALLOWLIST": {
+      "value": "True"
+    },
+    "EMAIL_ALLOWLIST": {
+      "value": ["admin@thinknimble.com"]
     }
   },
   "addons": ["heroku-postgresql:standard-0", "papertrail:choklad"],

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/platform_metrics.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/management/commands/platform_metrics.py
@@ -1,0 +1,30 @@
+import logging
+
+from decouple import config
+from django.contrib.auth import get_user_model
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from {{ cookiecutter.project_slug }}.utils.emails import send_html_email
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Alert the team on potentially important platform metrics"
+
+    def handle(self, *args, **kwargs):
+        logger.info(f"Starting management command {__name__}")
+        email_content = ""
+
+        recent_user_signups = User.objects.values("created__date").annotate(count=Count("created__date")).order_by("-created__date").values_list("created__date", "count")[0:7]
+        for date, count in recent_user_signups:
+            email_content += f"{date}: {count}</br>"
+
+        title = "{{ cookiecutter.project_name }} Platform Metrics"
+        context = {
+            "content": email_content
+        }
+        send_html_email(title, "core/metrics.html", settings.DEFAULT_FROM_EMAIL, [settings.STAFF_EMAIL], context=context)
+
+        logger.info(f"Finished management command {__name__}")

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
@@ -1,3 +1,6 @@
+from email.utils import parseaddr
+
+from django.conf import settings
 from django.contrib.auth import login
 from django.contrib.auth.password_validation import validate_password
 from rest_framework import serializers
@@ -61,10 +64,33 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
             "last_name": {"required": True},
         }
 
+    def _validate_name(self, value):
+        """
+        There are MANY unique names out there, so let users input whatever they want.
+        BUT...alert the devs if we see something odd.
+        """
+        if not "".join(a.split()).isalpha():
+            logger.warning(f"User signup with non-alphabetic characters in their name: {value}")
+
+    def validate_first_name(self, value):
+        self._validate_name(value)
+        return value
+
+    def validate_last_name(self, value):
+        self._validate_name(value)
+        return value
+
+    def validate_email(self, value):
+        value = value.lower()
+        if settings.USE_EMAIL_ALLOWLIST and value not in settings.EMAIL_ALLOWLIST:
+            raise ValidationError(detail="Invalid email")
+        # TODO - Test on new Python versions. It SHOULD raise validation errors
+        parseaddr(value)
+        return value
+
     def validate(self, data):
         password = data.get("password")
         validate_password(password)
-
         return data
 
     def create(self, validated_data):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/serializers.py
@@ -81,11 +81,13 @@ class UserRegistrationSerializer(serializers.ModelSerializer):
         return value
 
     def validate_email(self, value):
-        value = value.lower()
+        value = parseaddr(value, strict=True)[1].lower()
         if settings.USE_EMAIL_ALLOWLIST and value not in settings.EMAIL_ALLOWLIST:
             raise ValidationError(detail="Invalid email")
-        # TODO - Test on new Python versions. It SHOULD raise validation errors
-        parseaddr(value)
+        if not all(c in value for c in [".", "@"])
+            raise ValidationError(detail="Invalid email")
+        if not any(value.endswith(c) for c in [".com", ".net", ".org", ".co.uk"]):
+            logger.warning(f"Potentially risky email: {value}")
         return value
 
     def validate(self, data):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/templates/core/metrics.html
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/templates/core/metrics.html
@@ -1,0 +1,37 @@
+{%- raw -%}
+{% extends '_alert-email-base.html' %}
+{% load tz %}
+{% comment %}
+
+Platform Metrics
+
+Required context variables::
+
+:site_url: so we can link to the site this URL came from
+:support_email: email address to contact for support
+
+Content blocks::
+
+title - Large bolded title at the top of the message
+main_content - The important message
+button_link - URL for the action button on the page
+button_text - the label for the action button
+footer - closing thought on the message 
+
+{% endcomment %}
+
+{% block title %}Forgot your password?{% endblock %}
+
+{% block main_content %}
+<tr>
+  <td class="em_grey" align="center" valign="top" style="font-family: Arial, sans-serif; font-size: 16px; line-height: 26px; color:#434343;">It happens to the best of us. The good news is you can change it right now.</td>
+</tr>
+{% endblock main_content %}
+
+{% block footer %}
+<tr>
+  <td class="em_grey" align="center" valign="top" style="font-family: Arial, sans-serif; font-size: 16px; line-height: 26px; color:#434343;">If you didn&rsquo;t request a password reset, you don&rsquo;t have to do anything.<br class="em_hide" />
+Just ignore this email.</td>
+</tr>
+{% endblock footer %}
+{%- endraw -%}

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -259,6 +259,9 @@ if ENABLE_EMAILS:
 else:
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
+USE_EMAIL_ALLOWLIST = config("USE_EMAIL_ALLOWLIST", cast=bool, default=False)
+EMAIL_ALLOWLIST = config("EMAIL_ALLOWLIST", default=[])
+
 # STORAGES
 # ----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Checklist
- [x] Prevent random user signups by default
- [x] Allow devs to maintain an allowlist to minimize impact to rapid testing
- [x] pin Heroku server version for easier tracking of upgrades
- [x] Validate name and email formats for user signups
- [ ] Some sort of daily or weekly platform metrics report email
- [ ] Require Email verification on signup (possible separate PR)
