### PR TITLE
Fix Playwright GH Action

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -21,8 +21,8 @@ jobs:
         working-directory: ./client
         run: npx playwright test --reporter=html
         env:
-          PLAYWRIGHT_TEST_BASE_URL: {{ ${{ github.event.deployment_status.environment_url }} }}
-          PLAYWRIGHT_TEST_USER_PASS: {{ ${{ secrets.PLAYWRIGHT_TEST_USER_PASS }} }}
+          PLAYWRIGHT_TEST_BASE_URL: {{ "${{ github.event.deployment_status.environment_url }}" }}
+          PLAYWRIGHT_TEST_USER_PASS: {{ "${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}" }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -21,8 +21,8 @@ jobs:
         working-directory: ./client
         run: npx playwright test --reporter=html
         env:
-          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url }}
-          PLAYWRIGHT_TEST_USER_PASS: ${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}
+          PLAYWRIGHT_TEST_BASE_URL: {{ ${{ github.event.deployment_status.environment_url }} }}
+          PLAYWRIGHT_TEST_USER_PASS: {{ ${{ secrets.PLAYWRIGHT_TEST_USER_PASS }} }}
       - uses: actions/upload-artifact@v4
         if: failure()
         with:

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -7,18 +7,25 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.deployment_status.state == 'success'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
       - name: Install dependencies
-        run: npm --prefix ./client i
+        working-directory: ./client
+        run: npm install
       - name: Install Playwright
-        run: npx --prefix ./client playwright install --with-deps
+        working-directory: ./client
+        run: npx playwright install --with-deps
       - name: Run Playwright tests
-        run: npx --prefix ./client playwright test --reporter=html
+        working-directory: ./client
+        run: npx playwright test --reporter=html
         env:
-          PLAYWRIGHT_TEST_BASE_URL:
-            {{ "${{ github.event.deployment_status.environment_url }}" }}
-          PLAYWRIGHT_TEST_USER_PASS:
-            {{ "${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}" }}
+          PLAYWRIGHT_TEST_BASE_URL: ${{ github.event.deployment_status.environment_url }}
+          PLAYWRIGHT_TEST_USER_PASS: ${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: ./client/playwright-report/
+          retention-days: 30


### PR DESCRIPTION
## What this does

Playwright E2E tests are failing in CI on my newly-bootstrapped project with the error below.

I don't think the error is important. I believe the root cause is a working directory issue. This updates the GH Action config with working directory changes that have worked on other projects.

The error:

```bash
SyntaxError: /Users/william/thinknimble/darksaber/client/src/components/HelloWorld.vue: Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>? (79:0)

  77 | </template>
  78 |
> 79 | <script>
     | ^
  80 | export default {
  81 |   name: 'HelloWorld',
  82 |   props: {

   at client/tests/unit/example.test.ts:79
```