### PR TITLE
Migrate from WSGI to ASGI

### DIFF
--- a/scripts/buildpack_run.sh
+++ b/scripts/buildpack_run.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
-# curl -LsSf https://astral.sh/uv/install.sh | sh
-export PATH=$HOME/.local/bin:$PATH
+export PATH=$HOME/.local/bin:$PATH  # uv and uvx are installed in this directory
 uvx cookiecutter . --config-file cookiecutter/react_template.yaml --no-input -f


### PR DESCRIPTION
## What this does

Makes the bootstrapper async by default using ASGI and Django channels.

## Checklist

- [ ] Replace WSGI configs with ASGI configs
- [ ] Add chatbot demonstration
