### PR TITLE
Don't .gitignore .python-version and remove 'version' from docker-compose.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,9 +58,6 @@ docs/_build/
 # PyBuilder
 target/
 
-# pyenv
-.python-version
-
 # celery beat schedule file
 celerybeat-schedule
 

--- a/{{cookiecutter.project_slug}}/.gitignore
+++ b/{{cookiecutter.project_slug}}/.gitignore
@@ -63,9 +63,6 @@ coverage.xml
 # PyBuilder
 target/
 
-# pyenv
-.python-version
-
 # celery beat schedule file
 celerybeat-schedule
 

--- a/{{cookiecutter.project_slug}}/docker-compose.yaml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 volumes:
   local_postgres_data: {}
   local_postgres_data_backups: {}


### PR DESCRIPTION
This PR includes two changes:

1. Heroku now uses `.python-version` instead of `runtime.txt`. We should not gitignore this file anymore.
2. Removes the 'version' key from docker-compose.yaml, since it is now deprecated.