### PR TITLE
update boto3, move chat to urls, move core to its own url

### DIFF
--- a/{{cookiecutter.project_slug}}/docker-compose.yaml
+++ b/{{cookiecutter.project_slug}}/docker-compose.yaml
@@ -5,7 +5,7 @@ volumes:
 services:
   postgres:
     restart: always
-    image: postgres:12
+    image: postgres:16
     ports:
       - 5432:5432
     env_file:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -5,7 +5,7 @@ description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "boto3==1.18.26",
+    "boto3==1.37.15",
     "channels==4.2.*",
     "channels-redis==4.2",
     "daphne>=4.1.2",
@@ -52,3 +52,6 @@ dev = [
 
 [tool.ruff]
 line-length = 100
+
+[tool.ruff.lint]
+extend-select = ["I"]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -53,8 +53,9 @@ dev = [
 [tool.ruff]
 line-length = 100
 exclude = [
-    "server/migrations"
+    "**/migrations/*"
 ]
+
 
 [tool.ruff.lint]
 extend-select = ["I"]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
 
 [tool.ruff]
 line-length = 100
+exclude = [
+    "server/migrations"
+]
 
 [tool.ruff.lint]
 extend-select = ["I"]

--- a/{{cookiecutter.project_slug}}/server/README.md
+++ b/{{cookiecutter.project_slug}}/server/README.md
@@ -13,3 +13,11 @@ Once db credentials are set:
 1. `cd server`
 1. `python manage.py migrate` to migrate database
 1. `python manage.py runserver` to run the Django API (default - localhost:8000/admin)
+
+
+## Linting 
+[WIP]
+
+`ruff format`
+
+`ruff check --fix`

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
@@ -1,6 +1,6 @@
 import pytest
 
-from rapa.chat.models import PromptTemplate
+from .models import PromptTemplate
 
 
 @pytest.mark.django_db

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
@@ -1,0 +1,12 @@
+import pytest
+
+from rapa.chat.models import PromptTemplate
+
+
+@pytest.mark.django_db
+def test_chat_system_prompt_view(api_client, sample_user):
+    api_client.force_authenticate(user=sample_user)
+    PromptTemplate.objects.create(content="Hello, how can I help you today?", name="Welcome")
+    response = api_client.get("/api/chat/system-prompt/")
+    assert response.status_code == 200
+    assert response.data["content"] == "Hello, how can I help you today?"

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/urls.py
@@ -1,0 +1,5 @@
+from django.urls import path
+
+from . import views as chat_views
+
+urlpatterns = [path("system-prompt/", chat_views.get_current_system_prompt, name="system-prompt")]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
@@ -12,20 +12,17 @@ from rest_framework import permissions
 from rest_framework_nested import routers
 
 from {{ cookiecutter.project_slug }}.common import views as common_views
-from {{ cookiecutter.project_slug }}.core import urls as core_urls
 
 router = routers.SimpleRouter()
 if settings.DEBUG:
     router = routers.DefaultRouter()
 
-# extend url patterns here
-urlpatterns = [*core_urls.urlpatterns]
 
 SpectacularAPIView.permission_classes = (permissions.IsAuthenticated,)
 SpectacularSwaggerView.permission_classes = (permissions.IsAuthenticated,)
 SpectacularRedocView.permission_classes = (permissions.IsAuthenticated,)
 
-urlpatterns = urlpatterns + [
+urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     # Optional UI:
     path(

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/urls.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.urls import include, path
 from rest_framework_nested import routers
 
-from {{ cookiecutter.project_slug }}.chat.views import get_current_system_prompt
 from {{ cookiecutter.project_slug }}.core import views as core_views
 
 router = routers.SimpleRouter()
@@ -24,5 +23,4 @@ urlpatterns = [
     path(r"api/password/reset/", core_views.request_reset_link),
     path(r"api/password/change/", rest_auth_views.PasswordChangeView.as_view()),
     path(r"api/template_preview/", core_views.PreviewTemplateView.as_view()),
-    path("api/system-prompt/", get_current_system_prompt, name="system-prompt"),
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -7,7 +7,8 @@ admin.site.site_title = "{{ cookiecutter.project_name }}"
 urlpatterns = [
     path(r"staff/", admin.site.urls),
     path(r"api/chat/", include("{{ cookiecutter.project_slug }}.chat.urls")),
+    # order matters
+    path(r"", include("{{ cookiecutter.project_slug }}.core.urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.common.favicon_urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.common.urls")),
-    path(r"", include("{{ cookiecutter.project_slug }}.core.urls")),
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/urls.py
@@ -6,6 +6,8 @@ admin.site.site_title = "{{ cookiecutter.project_name }}"
 
 urlpatterns = [
     path(r"staff/", admin.site.urls),
+    path(r"api/chat/", include("{{ cookiecutter.project_slug }}.chat.urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.common.favicon_urls")),
     path(r"", include("{{ cookiecutter.project_slug }}.common.urls")),
+    path(r"", include("{{ cookiecutter.project_slug }}.core.urls")),
 ]


### PR DESCRIPTION
## What this does

Updates Boto3 since the current version in the Bootsrapper does not work with python 3.12
Moves the chat component to its own urls file 
Separates out the URLS for core
Adds sorting extension to RUFF

## How to test

Add user steps to achieve desired functionality for this feature.
