### PR TITLE
updated chat interface

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
@@ -35,6 +35,7 @@
         "@faker-js/faker": "^9.9.0",
         "@playwright/test": "^1.46.0",
         "@tanstack/eslint-plugin-query": "^5.86.0",
+        "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.2.0",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.4.3",
@@ -2380,7 +2381,6 @@
       "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",

--- a/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
@@ -25,6 +25,7 @@
         "react-icons": "^4.10.1",
         "react-resizable-panels": "^4.6.1",
         "react-router-dom": "^6.15.0",
+        "react-use-websocket": "^4.13.0",
         "tailwind-merge": "^3.2.0",
         "zod": "^3.24.1",
         "zustand": "^4.4.0"
@@ -9073,6 +9074,12 @@
         "react": ">=16.8",
         "react-dom": ">=16.8"
       }
+    },
+    "node_modules/react-use-websocket": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.13.0.tgz",
+      "integrity": "sha512-anMuVoV//g2N76Wxqvqjjo1X48r9Np3y1/gMl7arX84tAPXdy5R7sB5lO5hvCzQRYjqXwV8XMAiEBOUbyrZFrw==",
+      "license": "MIT"
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/{{cookiecutter.project_slug}}/clients/web/react/package.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package.json
@@ -34,6 +34,7 @@
     "react-icons": "^4.10.1",
     "react-resizable-panels": "^4.6.1",
     "react-router-dom": "^6.15.0",
+    "react-use-websocket": "^4.13.0",
     "tailwind-merge": "^3.2.0",
     "zod": "^3.24.1",
     "zustand": "^4.4.0"

--- a/{{cookiecutter.project_slug}}/clients/web/react/package.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package.json
@@ -45,6 +45,7 @@
     "@playwright/test": "^1.46.0",
     "@tanstack/eslint-plugin-query": "^5.86.0",
     "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/dom": "^10.4.0",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
     "@types/node": "^22.1.0",

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/api.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/api.ts
@@ -1,0 +1,11 @@
+import { createApi } from '@thinknimble/tn-models'
+import { chatShape } from './models'
+import { axiosInstance } from '../axios-instance'
+
+export const chatApi = createApi({
+  client: axiosInstance,
+  baseUri: '/chat',
+  models: {
+    entity: chatShape,
+  },
+})

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/index.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/index.ts
@@ -1,0 +1,3 @@
+export * from './api'
+export * from './models'
+export * from './queries'

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/models.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/models.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod'
+
+export const chatShape = {
+  id: z.string(),
+  name: z.string(),
+  completed: z.boolean(),
+}

--- a/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/queries.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/services/chat/queries.ts
@@ -1,0 +1,18 @@
+import { queryOptions } from '@tanstack/react-query'
+import { chatApi } from './api'
+
+export const chatQueries = {
+  all: () => ['chat'],
+  retrieve: (id: string) =>
+    queryOptions({
+      queryKey: [...chatQueries.all(), id],
+      queryFn: () => chatApi.retrieve(id),
+      enabled: Boolean(id),
+    }),
+  list: () =>
+    queryOptions({
+      queryKey: chatQueries.all(),
+      queryFn: () => chatApi.list(),
+      enabled: true,
+    }),
+}


### PR DESCRIPTION
## Summary

Refactors the chat interface to use `react-use-websocket` and adds a new chat service layer (`api/models/queries`) wired through TanStack Query.

## What Changed

- Replaced manual `WebSocket` lifecycle handling in `chat-interface.tsx` with `react-use-websocket`
- Added loading and connection-error UI states in the chat interface
- Added chat service files:
  - `src/services/chat/api.ts`
  - `src/services/chat/models.ts`
  - `src/services/chat/queries.ts`
  - `src/services/chat/index.ts`
- Added dependencies:
  - `react-use-websocket`
  - `@testing-library/dom`

## Current Notes / Follow-ups

- The new chat query path assumes a list endpoint under `/api/chat` and uses `chats?.results?.[0]?.id` for `chat_id`.
- This should be validated against currently available backend routes before approval.
- Frontend tests were not added for websocket lifecycle/error-state behavior in this PR.

## CI / Merge State

- Rebased onto latest `main`
- Mergeable from a git-conflict standpoint
- `Setup` check is currently failing due to Heroku app setup environment, while lint/tests are passing
