### PR TITLE
Remove heroku-buildpack-uv 

### DIFF
--- a/app.json
+++ b/app.json
@@ -37,9 +37,6 @@
   },
   "buildpacks": [
     {
-      "url": "https://github.com/dropseed/heroku-buildpack-uv.git"
-    },
-    {
       "url": "heroku/python"
     },
     {
@@ -50,9 +47,6 @@
     },
     {
       "url": "heroku/nodejs"
-    },
-    {
-      "url": "https://github.com/dropseed/heroku-buildpack-uv.git"
     },
     {
       "url": "heroku/python"

--- a/{{cookiecutter.project_slug}}/app.json
+++ b/{{cookiecutter.project_slug}}/app.json
@@ -48,9 +48,6 @@
       "url": "heroku/nodejs"
     },
     {
-      "url": "https://github.com/dropseed/heroku-buildpack-uv.git"
-    },
-    {
       "url": "heroku/python"
     }
   ],


### PR DESCRIPTION
## What this does

Removes `heroku-buildpack-uv` as it is no longer needed, since the `heroku/python` buildpack now supports uv.