### PR TITLE
Agent Types on Prompt Template

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -8,3 +8,4 @@ filterwarnings =
 
 markers =
     use_requests: Allow a unit test to call the internet
+    asyncio: Mark test as using asyncio

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/consumers.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/consumers.py
@@ -17,7 +17,9 @@ class ChatConsumer(AsyncJsonWebsocketConsumer):
     async def connect(self):
         self.user = self.scope["user"]
         # Generate a fresh system prompt for this connection using async version
-        self.system_prompt = await PromptTemplate.objects.aget_assembled_prompt()
+        self.system_prompt = await PromptTemplate.objects.aget_assembled_prompt(
+            agent=PromptTemplate.AgentType.CHAT
+        )
         await self.accept()
         self.groups = ["chat"]
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/fixtures/prompt_templates.json
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/fixtures/prompt_templates.json
@@ -7,7 +7,8 @@
       "description": "Initial prompt that sets up the consultant's role and personality",
       "order": 0,
       "created": "2024-02-27T00:00:00Z",
-      "last_edited": "2024-02-27T00:00:00Z"
+      "last_edited": "2024-02-27T00:00:00Z",
+      "agent_types": ["CHAT"]
     }
   },
   {
@@ -18,7 +19,8 @@
       "description": "Concluding instructions and special commands",
       "order": 999,
       "created": "2024-02-27T00:00:00Z",
-      "last_edited": "2024-02-27T00:00:00Z"
+      "last_edited": "2024-02-27T00:00:00Z",
+      "agent_types": ["CHAT"]	
     }
   }
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/fixtures/prompt_templates.json
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/fixtures/prompt_templates.json
@@ -20,7 +20,7 @@
       "order": 999,
       "created": "2024-02-27T00:00:00Z",
       "last_edited": "2024-02-27T00:00:00Z",
-      "agent_types": ["CHAT"]	
+      "agent_types": ["CHAT"]
     }
   }
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/migrations/0001_initial.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/migrations/0001_initial.py
@@ -85,6 +85,20 @@ class Migration(migrations.Migration):
                         help_text="Order in which this template will appear in the system prompt",
                     ),
                 ),
+                (
+                    "agent_types",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.CharField(
+                            choices=[
+                                ("CHAT", "Chat"),
+                            ]
+                        ),
+                        blank=True,
+                        default=list,
+                        help_text="List of agent types this template is for. Leave empty for none.",
+                        size=None,
+                    ),
+                ),
             ],
             options={
                 "verbose_name": "Prompt Template",

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
@@ -118,7 +118,7 @@ class PromptTemplateManager(models.Manager):
 
     async def aget_assembled_prompt(self, agent: str | None = None):
         """Async version of get_assembled_prompt"""
-        return await sync_to_async(self.get_assembled_prompt)()
+        return await sync_to_async(self.get_assembled_prompt)(agent=agent)
 
 
 class PromptTemplate(AbstractBaseModel):

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
@@ -4,7 +4,7 @@ from asgiref.sync import sync_to_async
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-from {{ cookiecutter.project_slug }}.common.models import AbstractBaseModel
+from test_agents.common.models import AbstractBaseModel
 
 from .exceptions import BadTemplateException
 
@@ -75,12 +75,16 @@ class Feedback(AbstractBaseModel):
 
 
 class PromptTemplateManager(models.Manager):
-    def get_assembled_prompt(self):
+    def get_assembled_prompt(self, agent: str | None = None):
         """Returns the assembled system prompt using all templates and fingerprints"""
         from .models import Fingerprint  # Local import to avoid circular dependency
 
         # Get active templates ordered by order field
         templates = self.get_queryset().order_by("order")
+
+        # Filter by agent if specified
+        if agent:
+            templates = templates.filter(agent_types__contains=[agent])
 
         # Get all fingerprints and sort by name
         fingerprints = Fingerprint.objects.all().order_by("name")
@@ -112,12 +116,15 @@ class PromptTemplateManager(models.Manager):
 
         return "\n\n".join(formatted_templates)
 
-    async def aget_assembled_prompt(self):
+    async def aget_assembled_prompt(self, agent: str | None = None):
         """Async version of get_assembled_prompt"""
         return await sync_to_async(self.get_assembled_prompt)()
 
 
 class PromptTemplate(AbstractBaseModel):
+    class AgentType(models.TextChoices):
+        CHAT = "CHAT", "Chat"
+
     name = models.CharField(max_length=255, help_text="Short descriptive name for this template")
     content = models.TextField(
         help_text="The template content. Supported placeholders are {fingerprint_dialogue_examples} like {categories}"
@@ -127,6 +134,12 @@ class PromptTemplate(AbstractBaseModel):
     )
     order = models.PositiveIntegerField(
         default=0, help_text="Order in which this template will appear in the system prompt"
+    )
+    agent_types = ArrayField(
+        models.CharField(choices=AgentType.choices),
+        default=list,
+        blank=True,
+        help_text="List of agent types this template is for. Leave empty for none.",
     )
 
     objects = PromptTemplateManager()

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/models.py
@@ -4,7 +4,7 @@ from asgiref.sync import sync_to_async
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 
-from test_agents.common.models import AbstractBaseModel
+from {{ cookiecutter.project_slug }}.common.models import AbstractBaseModel
 
 from .exceptions import BadTemplateException
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
@@ -10,3 +10,64 @@ def test_chat_system_prompt_view(api_client, sample_user):
     response = api_client.get("/api/chat/system-prompt/")
     assert response.status_code == 200
     assert response.data["content"] == "Hello, how can I help you today?"
+
+
+@pytest.mark.django_db
+def test_prompt_template_agent_type_filtering():
+    # Create templates with different agent types
+    PromptTemplate.objects.create(
+        name="Chat Template",
+        content="This is a chat template",
+        agent_types=[PromptTemplate.AgentType.CHAT],
+        order=1
+    )
+
+    PromptTemplate.objects.create(
+        name="No Agent Template",
+        content="This template has no agent types",
+        agent_types=[],
+        order=2
+    )
+
+    # Test filtering by CHAT agent type
+    prompt_with_chat = PromptTemplate.objects.get_assembled_prompt(
+        agent=PromptTemplate.AgentType.CHAT
+    )
+
+    # Should only include the chat template
+    assert "This is a chat template" in prompt_with_chat
+    assert "This template has no agent types" not in prompt_with_chat
+
+    # Test with no agent filter - should include all templates
+    prompt_no_filter = PromptTemplate.objects.get_assembled_prompt()
+    assert "This is a chat template" in prompt_no_filter
+    assert "This template has no agent types" in prompt_no_filter
+
+
+@pytest.mark.django_db
+@pytest.mark.asyncio
+async def test_prompt_template_async_agent_filtering():
+    # Create a template with CHAT agent type
+    await PromptTemplate.objects.acreate(
+        name="Async Chat Template",
+        content="Async chat content",
+        agent_types=[PromptTemplate.AgentType.CHAT],
+        order=1
+    )
+
+    # Create a template without agent types
+    await PromptTemplate.objects.acreate(
+        name="Async General Template",
+        content="General content",
+        agent_types=[],
+        order=2
+    )
+
+    # Test async filtering with agent parameter
+    prompt_with_agent = await PromptTemplate.objects.aget_assembled_prompt(
+        agent=PromptTemplate.AgentType.CHAT
+    )
+
+    # Should only include the chat template
+    assert "Async chat content" in prompt_with_agent
+    assert "General content" not in prompt_with_agent

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/chat/tests.py
@@ -19,14 +19,14 @@ def test_prompt_template_agent_type_filtering():
         name="Chat Template",
         content="This is a chat template",
         agent_types=[PromptTemplate.AgentType.CHAT],
-        order=1
+        order=1,
     )
 
     PromptTemplate.objects.create(
         name="No Agent Template",
         content="This template has no agent types",
         agent_types=[],
-        order=2
+        order=2,
     )
 
     # Test filtering by CHAT agent type
@@ -52,7 +52,7 @@ async def test_prompt_template_async_agent_filtering():
         name="Async Chat Template",
         content="Async chat content",
         agent_types=[PromptTemplate.AgentType.CHAT],
-        order=1
+        order=1,
     )
 
     # Create a template without agent types
@@ -60,7 +60,7 @@ async def test_prompt_template_async_agent_filtering():
         name="Async General Template",
         content="General content",
         agent_types=[],
-        order=2
+        order=2,
     )
 
     # Test async filtering with agent parameter


### PR DESCRIPTION
## What this does

This PR adds agent type support to the PromptTemplate model, allowing prompt templates to be filtered and associated with specific agent types. This enables different AI agents to use different sets of prompt templates based on their specific roles.

## Changes Made

- Added `AgentType` enum to PromptTemplate model with initial `CHAT` type
- Added `agent_types` ArrayField to store multiple agent types per template
- Updated `get_assembled_prompt()` and `aget_assembled_prompt()` methods to accept an optional `agent` parameter for filtering
- Modified ChatConsumer to specify `CHAT` agent type when fetching prompts
- Updated fixtures to include agent_types field for existing templates
- Added database migration for the new field

## Checklist
- [x] Added AgentType enum with CHAT option
- [x] Implemented agent_types ArrayField on PromptTemplate model
- [x] Updated manager methods to support agent filtering
- [x] Modified ChatConsumer to use agent-specific prompts
- [x] Updated fixtures with agent_types data
- [x] Created migration for schema changes

## How to test

1. Run migrations: `python manage.py migrate`
2. Load updated fixtures: `python manage.py loaddata chat/fixtures/prompt_templates.json`
3. Connect to the chat WebSocket endpoint
4. Verify that only templates with `CHAT` agent type are included in the system prompt
5. Create a new template without agent_types and verify it's not included for CHAT agents
6. Create a new template with `CHAT` in agent_types and verify it's included