### PR TITLE
Upgrade Node.js to v22 and optimize Playwright workflow

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-build.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-build.yml
@@ -41,7 +41,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: npm
           cache-dependency-path: ./mobile/package-lock.json
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-emergency-prod-update.yml
@@ -18,7 +18,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
 
       - name: 🏗 Setup Expo and EAS
         uses: expo/expo-github-action@v8

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-main.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: npm
           cache-dependency-path: ./mobile/package-lock.json
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
 
       - name: 🏗 Setup Expo and EAS
         uses: expo/expo-github-action@v8

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-android.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: npm
           cache-dependency-path: ./package-lock.json
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/expo-teststore-build-ios.yml
@@ -15,7 +15,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
           cache: npm
           cache-dependency-path: ./mobile/package-lock.json
 

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
       - name: 📦 Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false
@@ -50,7 +50,7 @@ jobs:
       - name: 🏗 Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 22.x
       - name: 📦 Install dependencies
         working-directory: ./mobile
         run: npm install

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -1,27 +1,44 @@
 name: Playwright Tests
 on:
   deployment_status:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: 'Base URL to test against'
+        required: false
+        default: ''
 jobs:
   test:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: github.event.deployment_status.state == 'success'
+    container:
+      image: mcr.microsoft.com/playwright:v1.49.1-noble
+    if: github.event.deployment_status.state == 'success' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4
+        with:
+          # For deployment_status events, we need to explicitly checkout the deployment's ref
+          ref: {{ "${{ github.event.deployment.sha || github.ref }}" }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: ./client/package-lock.json
       - name: Install dependencies
         working-directory: ./client
-        run: npm install
-      - name: Install Playwright
+        run: npm ci
+      # Browsers are pre-installed in the Playwright Docker image
+      # No need to install them again!
+      - name: Create .env file for Playwright
         working-directory: ./client
-        run: npx playwright install --with-deps
+        run: |
+          echo "PLAYWRIGHT_TEST_USER_PASS={{ "${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}" }}" > .env
       - name: Run Playwright tests
         working-directory: ./client
         run: npx playwright test --reporter=html
         env:
-          PLAYWRIGHT_TEST_BASE_URL: {{ "${{ github.event.deployment_status.environment_url }}" }}
+          HOME: /root  # Required for Firefox to run in the container
+          PLAYWRIGHT_TEST_BASE_URL: {{ "${{ github.event.deployment_status.environment_url || github.event.inputs.base_url }}" }}
           PLAYWRIGHT_TEST_USER_PASS: {{ "${{ secrets.PLAYWRIGHT_TEST_USER_PASS }}" }}
       - uses: actions/upload-artifact@v4
         if: failure()

--- a/{{cookiecutter.project_slug}}/compose/client/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app/client
 

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -4,8 +4,8 @@
     "heroku-postbuild": "cd client && npm run build"
   },
   "engines": {
-    "node": "18.*.*",
-    "npm": "9.*.*"
+    "node": "22.*.*",
+    "npm": "10.*.*"
   },
   "cacheDirectories": [
     "client/node_modules",


### PR DESCRIPTION
## Summary
- Upgraded Node.js from version 18 to 22 across the entire cookiecutter template
- Implemented Playwright workflow optimizations based on PathAhead/cue_platform_django#4
- Significantly reduced CI runtime through Docker containerization

## Changes

### Node.js Upgrade (v18 → v22)
- Updated all GitHub Actions workflows to use Node.js 22
- Updated Docker base image to `node:22-alpine`
- Updated package.json engines to require Node 22 and npm 10

### Playwright Workflow Optimizations
- **Docker Container**: Now uses `mcr.microsoft.com/playwright:v1.49.1-noble` with pre-installed browsers
- **Manual Triggers**: Added `workflow_dispatch` for manual test runs with custom base URLs
- **NPM Caching**: Implemented caching for faster dependency installation
- **npm ci**: Switched from `npm install` to `npm ci` for deterministic installs
- **Environment Setup**: Added `HOME=/root` for Firefox compatibility in container

## Performance Impact
These changes eliminate browser installation time and reduce dependency installation time, resulting in significantly faster CI runs.

## Test Plan
- [ ] GitHub Actions workflows pass successfully
- [ ] Playwright tests run in Docker container
- [ ] Node.js 22 compatibility verified across all environments