### PR TITLE
[codex] align node versions to 22.x

### DIFF
--- a/.github/actions/upload-to-google-docs/action.yml
+++ b/.github/actions/upload-to-google-docs/action.yml
@@ -22,5 +22,5 @@ outputs:
   webViewLink:
     description: 'A link to view the document in the browser.'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -57,7 +57,7 @@ jobs:
           path: my_project/
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.x
           cache: 'npm'
           cache-dependency-path: ./my_project/client/package-lock.json
       - name: 📦 Install frontend dependencies

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,7 +84,7 @@ jobs:
           uv run cookiecutter . --config-file $config_file --no-input -f
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.x
       - name: 📦 Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: 22.x
 
       - name: Install dependencies
         run: npm install @actions/core googleapis

--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.x
       - name: 📦 Install dependencies
         env:
           NPM_CONFIG_PRODUCTION: false

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ jobs:
           ref: {{ "${{ github.event.deployment.sha || github.ref }}" }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.x
           cache: 'npm'
           cache-dependency-path: ./client/package-lock.json
       - name: Install dependencies

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/README.md
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/README.md
@@ -1,6 +1,6 @@
 ## Getting Started
 
-This app is bootstrapped with the TN-Bootsrapper and uses Expo as a wrapper framework around React Native. Install and run with **Node v20**.
+This app is bootstrapped with the TN-Bootsrapper and uses Expo as a wrapper framework around React Native. Install and run with **Node v22**.
 
 ## Installing and Running
 
@@ -78,13 +78,13 @@ When running the Expo mobile app inside Docker, the Metro bundler and developmen
 
 ### iOS Simulator
 
-1. **Start the iOS Simulator**  
+1. **Start the iOS Simulator**
    Open Xcode, or run:
    ```sh
    open -a Simulator
    ```
 
-2. **Install the app**  
+2. **Install the app**
    If you are using a custom dev client, run:
    ```sh
    npx expo run:ios
@@ -93,13 +93,13 @@ When running the Expo mobile app inside Docker, the Metro bundler and developmen
 
 ### Android Emulator
 
-1. **Start the Android Emulator**  
+1. **Start the Android Emulator**
    Open Android Studio and start an emulator, or run:
    ```sh
    emulator -avd <your_avd_name>
    ```
 
-2. **Install the app**  
+2. **Install the app**
    If you are using a custom dev client, run:
    ```sh
    npx expo run:android

--- a/{{cookiecutter.project_slug}}/compose/mobile/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/mobile/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app/mobile
 
@@ -7,4 +7,3 @@ COPY ./mobile/package.json /app/mobile/package.json
 RUN npm i
 
 CMD ["npm", "run", "start:docker"]
-

--- a/{{cookiecutter.project_slug}}/package.json
+++ b/{{cookiecutter.project_slug}}/package.json
@@ -4,8 +4,8 @@
     "heroku-postbuild": "cd client && npm run build"
   },
   "engines": {
-    "node": "22.*.*",
-    "npm": "10.*.*"
+    "node": "22.x",
+    "npm": "10.x"
   },
   "cacheDirectories": [
     "client/node_modules",


### PR DESCRIPTION
## Problem
`feature/docker-mobile` introduced a mobile Docker image pinned to Node 18, while most of the repository and template CI paths were already on Node 22 and mobile docs referenced Node 20. This created version drift across local development, Docker, CI, and generated template projects.

From a developer perspective, this mismatch can produce inconsistent install/lint/build behavior depending on where commands run (host machine vs Docker vs GitHub Actions), and it increases maintenance cost when troubleshooting environment-specific issues.

## Root Cause
Node runtime declarations were maintained in multiple places (Dockerfiles, GitHub workflows, docs, template engine constraints, and local GitHub action runtime metadata), and those references evolved independently over time.

## Fix
This PR aligns runtime declarations to a single canonical target of **Node 22.x** for project/tooling execution, and removes stale/deprecated runtime references:

- Updated mobile Docker image to `node:22-alpine`.
- Standardized `actions/setup-node` references to `22.x` where mixed formats (`22`, `'22'`, `22.x`) were present.
- Updated template mobile README from Node 20 guidance to Node 22 guidance.
- Normalized template root engine constraints from `22.*.*`/`10.*.*` to `22.x`/`10.x`.
- Updated local JavaScript GitHub Action runtime from `node16` to `node20` (required because GitHub Actions JS runtimes are versioned separately from project runtime and `node16` is deprecated).

## Validation
Ran the following checks in the worktree:

- `UV_CACHE_DIR=.uv-cache uv run ruff check .` ✅
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_cookiecutter_generation.py` ✅ (`7 passed, 1 skipped`)
- Repo-wide grep audit for stale references (`node:18`, `node-version: 18/20`, `Node v20`, `using: 'node16'`) ✅ no matches

## Compatibility Notes / Risks
The template web lockfile currently includes at least one dependency constraint requiring `^20.19.0 || >=22.12.0`. Using `22.x` remains correct, but CI/dev images should not pin to early Node 22 patch versions lower than `22.12.0`.

## Scope
Only Node version alignment files were changed (9 files total), with no application logic changes.
