### PR TITLE
Add root worktree justfile; align worktree dir naming across justfiles + specs

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,7 +12,11 @@ worktree action branch:
     set -e
 
     BRANCH="{{ branch }}"
-    dir_name=$(echo "$BRANCH" | sed -E 's,^(feature|bugfix|hotfix|fix|chore|release)/,,' | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
+    # Derive the worktree dir slug with the same branch->name rule the generated
+    # project's justfile uses for PROJECT: strip a leading type prefix (word/ or
+    # word_), lowercase, slashes/underscores -> hyphens, drop other chars.
+    # e.g. feature/auth_bug -> auth-bug
+    dir_name=$(echo "$BRANCH" | sed 's|^[a-zA-Z][a-zA-Z0-9]*[/_]||' | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
     worktree_path="../tn-spa-bootstrapper-${dir_name}"
 
     if [ "{{ action }}" = "add" ]; then

--- a/justfile
+++ b/justfile
@@ -1,0 +1,48 @@
+# TN SPA Bootstrapper — Development Commands
+
+# Set default recipe to list commands
+default:
+    @just --list
+
+# Manage git worktrees for parallel development.
+# Usage: just worktree add <branch>    — create worktree
+#        just worktree remove <branch> — remove worktree
+worktree action branch:
+    #!/usr/bin/env bash
+    set -e
+
+    BRANCH="{{ branch }}"
+    dir_name=$(echo "$BRANCH" | sed -E 's,^(feature|bugfix|hotfix|fix|chore|release)/,,' | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
+    worktree_path="../tn-spa-bootstrapper-${dir_name}"
+
+    if [ "{{ action }}" = "add" ]; then
+      echo "Creating worktree for branch '$BRANCH' at $worktree_path..."
+      if git show-ref --verify --quiet "refs/heads/$BRANCH" || git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+        git worktree add "$worktree_path" "$BRANCH"
+      else
+        git worktree add -b "$BRANCH" "$worktree_path"
+      fi
+
+      echo ""
+      echo "Worktree ready at: $worktree_path"
+      echo "  cd $worktree_path"
+      echo ""
+
+    elif [ "{{ action }}" = "remove" ]; then
+      if [ ! -d "$worktree_path" ]; then
+        echo "Error: worktree not found at $worktree_path"
+        exit 1
+      fi
+
+      echo "Removing worktree..."
+      git worktree remove "$worktree_path" --force
+
+      echo ""
+      echo "Worktree '$BRANCH' removed."
+      echo "Note: branch not deleted. To delete: git branch -d $BRANCH"
+      echo ""
+
+    else
+      echo "Usage: just worktree add <branch> | just worktree remove <branch>"
+      exit 1
+    fi

--- a/specs/traefik-multi-project-routing/assertions/project-derived-from-branch.md
+++ b/specs/traefik-multi-project-routing/assertions/project-derived-from-branch.md
@@ -20,7 +20,9 @@ The justfile includes a `_project` helper that derives `PROJECT` from the curren
 | `feature/my-thing` | `<slug>-my-thing` |
 | `fix/auth_bug` | `<slug>-auth-bug` |
 
-Rules: lowercase, slashes/underscores → hyphens, strip non-`[a-z0-9-]` chars, prefix with project slug.
+Rules: strip a leading branch-type prefix (`word/` or `word_`), lowercase, slashes/underscores → hyphens, strip non-`[a-z0-9-]` chars, prefix with project slug.
+
+This branch→name rule is the single source of truth for both `_project` (operates on the current branch) and `just worktree` (operates on its `<branch>` argument — see `worktree-command`). A worktree's directory name therefore equals its container `PROJECT` namespace.
 
 ## Implementation
 

--- a/specs/traefik-multi-project-routing/assertions/worktree-command.md
+++ b/specs/traefik-multi-project-routing/assertions/worktree-command.md
@@ -19,9 +19,30 @@ just worktree add <branch>     # create worktree + run setup
 just worktree remove <branch>  # stop Docker stack + remove worktree
 ```
 
+## Directory Naming
+
+The worktree directory slug is derived from the `<branch>` argument using the
+**exact same rule** as the `_project` helper (see `project-derived-from-branch`):
+strip a leading branch-type prefix (`word/` or `word_`), lowercase,
+slashes/underscores → hyphens, strip non-`[a-z0-9-]` chars, then prefix with the
+project slug. This makes the worktree directory name equal the container
+`PROJECT` namespace, so `../<name>/` and its Docker stack share one identifier.
+
+The only difference from `_project` is the input: the rule operates on the
+`<branch>` **argument** (the target branch), not the currently-checked-out
+branch.
+
+| `<branch>` argument | Directory (and PROJECT) |
+|---------------------|-------------------------|
+| `main`              | `../<slug>-main/`       |
+| `feature/my-thing`  | `../<slug>-my-thing/`   |
+| `fix/auth_bug`      | `../<slug>-auth-bug/`   |
+| `feature/x`         | `../<slug>-x/`          |
+
 ## `add` Behavior
 
-1. Creates git worktree at `../<slug>-<branch-slug>/`
+1. Creates git worktree at `../<name>/`, where `<name>` is derived from the
+   `<branch>` argument per **Directory Naming** above
 2. Creates branch if it doesn't exist; checks out existing branch if it does
 3. Runs `just setup-dev` in the new worktree
 4. Prints instructions for starting the stack
@@ -34,7 +55,8 @@ just worktree remove <branch>  # stop Docker stack + remove worktree
 
 ## Success Criteria
 
-- ✅ `just worktree add feature/x` creates worktree at `../<slug>-x/`
+- ✅ `just worktree add feature/x` creates worktree at `../<slug>-x/` (leading `feature/` prefix stripped)
+- ✅ Directory name equals the container `PROJECT` namespace for the same branch
 - ✅ Creates branch if it doesn't exist
 - ✅ Checks out existing branch without error
 - ✅ `just worktree remove feature/x` stops services and removes directory

--- a/specs/traefik-multi-project-routing/traefik-multi-project-routing.md
+++ b/specs/traefik-multi-project-routing/traefik-multi-project-routing.md
@@ -44,7 +44,7 @@ Each generated project contains:
 
 ## Worktree Workflow
 
-`just worktree add <branch>` creates a git worktree with a fully isolated Docker stack. Each worktree runs its own containers under a unique `PROJECT` name with no port conflicts.
+`just worktree add <branch>` creates a git worktree with a fully isolated Docker stack. The worktree directory name and its `PROJECT` namespace are both derived from `<branch>` by the same branch→name rule (see PROJECT Isolation above), so the directory and its containers share one identifier. Each worktree runs its own containers under a unique `PROJECT` name with no port conflicts.
 
 ## Constraints
 

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -234,7 +234,10 @@ worktree action branch:
     set -e
 
     BRANCH="{{ "{{ branch }}" }}"
-    dir_name=$(echo "$BRANCH" | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
+    # Derive the worktree dir slug the same way _project derives PROJECT, so the
+    # directory name matches the container namespace (strip leading type prefix,
+    # e.g. feature/auth_bug -> auth-bug).
+    dir_name=$(echo "$BRANCH" | sed 's|^[a-zA-Z][a-zA-Z0-9]*[/_]||' | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
     worktree_path="../{{cookiecutter.project_slug}}-${dir_name}"
 
     if [ "{{ "{{ action }}" }}" = "add" ]; then


### PR DESCRIPTION
## What this does

Adds a root-level `justfile` with a `worktree add/remove <branch>` recipe for parallel development on the bootstrapper itself, and makes worktree directory naming consistent across the repo.

## Why the extra changes

The worktree dir slug was derived three different ways. All now use the canonical `_project` rule (strip leading `word/`|`word_` prefix, lowercase, `/_`→`-`, drop other chars), so the dir name equals the container `PROJECT` namespace and matches the specs. This also fixes an existing spec violation: the template's `worktree` recipe produced `<slug>-feature-x` where the spec requires `<slug>-x`.

## Changes

- `justfile` (new) — root worktree recipe
- `{{cookiecutter.project_slug}}/justfile` — `worktree` recipe now strips the branch-type prefix
- `specs/traefik-multi-project-routing/` — document the shared branch→name rule as single-source

Verified: `add`/`remove` work end-to-end; both justfiles share an identical derivation; pre-commit template linting passes.