### PR TITLE
Fix: patch npm mobile security vulnerabilities (axios, @xmldom/xmldom)

### DIFF
--- a/my_project/mobile/package-lock.json
+++ b/my_project/mobile/package-lock.json
@@ -25,7 +25,7 @@
         "@thinknimble/tn-forms": "3.3.3",
         "@thinknimble/tn-forms-react": "^1.0.3",
         "@thinknimble/tn-models": "^3.0.0",
-        "axios": "^1.3.2",
+        "axios": "^1.18.1",
         "clsx": "^2.1.1",
         "date-fns": "^2.29.3",
         "eslint-plugin-flowtype": "^8.0.3",
@@ -1763,15 +1763,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/@expo/config/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@expo/config/node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -2262,15 +2253,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/@expo/prebuild-config/node_modules/getenv": {
       "version": "2.0.0",
@@ -4642,11 +4624,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "dev": true,
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -5065,14 +5048,24 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-eslint": {
@@ -7474,15 +7467,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/expo-updates/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.0",
       "license": "MIT"
@@ -7649,15 +7633,6 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
@@ -8003,9 +7978,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10922,13 +10897,6 @@
       },
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/plist/node_modules/xmlbuilder": {

--- a/my_project/mobile/package.json
+++ b/my_project/mobile/package.json
@@ -43,7 +43,7 @@
     "@thinknimble/tn-forms": "3.3.3",
     "@thinknimble/tn-forms-react": "^1.0.3",
     "@thinknimble/tn-models": "^3.0.0",
-    "axios": "^1.3.2",
+    "axios": "^1.18.1",
     "clsx": "^2.1.1",
     "date-fns": "^2.29.3",
     "eslint-plugin-flowtype": "^8.0.3",
@@ -134,6 +134,7 @@
     "readdirp": { "picomatch": ">=2.3.2" },
     "jest-util": { "picomatch": ">=2.3.2" },
     "expo": { "picomatch": ">=3.0.2" },
-    "yaml": ">=2.8.3"
+    "yaml": ">=2.8.3",
+    "@xmldom/xmldom": ">=0.9.0"
   }
 }

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -25,7 +25,7 @@
         "@thinknimble/tn-forms": "3.3.3",
         "@thinknimble/tn-forms-react": "^1.0.3",
         "@thinknimble/tn-models": "^3.0.0",
-        "axios": "^1.3.2",
+        "axios": "^1.18.1",
         "clsx": "^2.1.1",
         "date-fns": "^2.29.3",
         "eslint-plugin-flowtype": "^8.0.3",
@@ -1763,15 +1763,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/@expo/config/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/@expo/config/node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -2262,15 +2253,6 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
-    },
-    "node_modules/@expo/prebuild-config/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
     },
     "node_modules/@expo/prebuild-config/node_modules/getenv": {
       "version": "2.0.0",
@@ -4642,11 +4624,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.7.13",
-      "dev": true,
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -5065,14 +5048,24 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/babel-eslint": {
@@ -7474,15 +7467,6 @@
         "xmlbuilder": "^15.1.1"
       }
     },
-    "node_modules/expo-updates/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.0",
       "license": "MIT"
@@ -7649,15 +7633,6 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
-      }
-    },
-    "node_modules/expo/node_modules/@xmldom/xmldom": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
-      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
@@ -8003,9 +7978,9 @@
       "license": "MIT"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -10922,13 +10897,6 @@
       },
       "engines": {
         "node": ">=10.4.0"
-      }
-    },
-    "node_modules/plist/node_modules/@xmldom/xmldom": {
-      "version": "0.8.10",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/plist/node_modules/xmlbuilder": {

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -43,7 +43,7 @@
     "@thinknimble/tn-forms": "3.3.3",
     "@thinknimble/tn-forms-react": "^1.0.3",
     "@thinknimble/tn-models": "^3.0.0",
-    "axios": "^1.3.2",
+    "axios": "^1.18.1",
     "clsx": "^2.1.1",
     "date-fns": "^2.29.3",
     "eslint-plugin-flowtype": "^8.0.3",
@@ -134,6 +134,7 @@
     "readdirp": { "picomatch": ">=2.3.2" },
     "jest-util": { "picomatch": ">=2.3.2" },
     "expo": { "picomatch": ">=3.0.2" },
-    "yaml": ">=2.8.3"
+    "yaml": ">=2.8.3",
+    "@xmldom/xmldom": ">=0.9.0"
   }
 }


### PR DESCRIPTION
## Summary

Patches HIGH and MEDIUM severity npm vulnerabilities in the React Native / Expo mobile template.

Changes applied to both the cookiecutter template (`{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json`) and the mirror (`my_project/mobile/package.json`).

### axios — bump `^1.3.2` → `^1.18.1`

Vulnerable range: `1.0.0 – 1.15.2`. Fixes 9 HIGH and multiple MEDIUM advisories including prototype pollution, SSRF, header injection, and credential leak vulnerabilities.

### @xmldom/xmldom — add `">=0.9.0"` override

Vulnerable range: `<=0.8.12`. Fixes 5 HIGH XML-injection/DoS advisories:

- GHSA-2v35-w6hq-6mfw: Uncontrolled recursion in XML serialization (DoS)
- GHSA-f6ww-3ggp-fr8h: XML injection via unvalidated DocumentType serialization
- GHSA-x6wf-f3px-wcqx: XML node injection via unvalidated processing instruction
- GHSA-j759-j44w-7fr8: XML node injection via unvalidated comment serialization
- GHSA-wh4c-j3r5-mjhp: XML injection via unsafe CDATA serialization

`@xmldom/xmldom` is a transitive dependency pulled in by `@expo/plist` (via `@expo/config-plugins` and `expo-updates`). Since no 0.8.x patch exists, we override to `>=0.9.0` (installed: `0.9.10`). This package is only used in build tooling (plist parsing during Expo prebuild), so the API bump risk is limited to the build/config phase.

## Test plan

- [ ] Confirm `npm ls axios` in mobile resolves to `^1.18.1`
- [ ] Confirm `npm ls @xmldom/xmldom` in mobile shows `0.9.10` across all dependents
- [ ] Verify CI passes (template linting, pre-commit hooks)