### PR TITLE
Fix getErrorMessages missing DRF {detail: string} error shape

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/web/react/src/utils/errors.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/src/utils/errors.ts
@@ -1,19 +1,19 @@
 import { isAxiosError } from 'axios'
 
-type ErrorData = string[] | { [key: string]: string[] }
+type ErrorData = string[] | { [key: string]: string[] | string }
 
 function extractErrorMessages(data: ErrorData | undefined): string[] {
   if (Array.isArray(data) && data.length && typeof data[0] === 'string') {
     return data
-  } else if (
-    typeof data === 'object' &&
-    Object.keys(data).every((key) => Array.isArray((data as { [key: string]: string[] })[key]))
-  ) {
-    // Use type assertion within every callback to access property with key
-    return Object.values(data).flat()
-  } else {
-    return ['Something went wrong']
+  } else if (typeof data === 'object' && data !== null) {
+    if ('detail' in data && typeof data['detail'] === 'string') {
+      return [data['detail']]
+    }
+    if (Object.values(data).every((v) => Array.isArray(v))) {
+      return Object.values(data as { [key: string]: string[] }).flat()
+    }
   }
+  return ['Something went wrong']
 }
 
 export function getErrorMessages(e: Error, defaultMessage = 'Something went wrong'): string[] {


### PR DESCRIPTION
Closes #526

## Summary

- `extractErrorMessages` now handles the `{ detail: string }` shape that DRF returns for non-field errors (auth failures, 403, 404, `raise ValidationError(detail="...")`)
- Widened `ErrorData` type to include `string` values alongside `string[]`
- Removed the misleading inline comment; simplified the conditional logic

## Before

```ts
type ErrorData = string[] | { [key: string]: string[] }

function extractErrorMessages(data: ErrorData | undefined): string[] {
  if (Array.isArray(data) && data.length && typeof data[0] === 'string') {
    return data
  } else if (
    typeof data === 'object' &&
    Object.keys(data).every((key) => Array.isArray((data as { [key: string]: string[] })[key]))
  ) {
    return Object.values(data).flat()
  } else {
    return ['Something went wrong']   // ← { detail: "..." } fell through to here
  }
}
```

## After

```ts
type ErrorData = string[] | { [key: string]: string[] | string }

function extractErrorMessages(data: ErrorData | undefined): string[] {
  if (Array.isArray(data) && data.length && typeof data[0] === 'string') {
    return data
  } else if (typeof data === 'object' && data !== null) {
    if ('detail' in data && typeof data['detail'] === 'string') {
      return [data['detail']]
    }
    if (Object.values(data).every((v) => Array.isArray(v))) {
      return Object.values(data as { [key: string]: string[] }).flat()
    }
  }
  return ['Something went wrong']
}
```