### PR TITLE
API paths answer JSON errors, not HTML

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -71,6 +71,15 @@ extend-select = ["I", "C90"]
 # not bugs, so silence the rule rather than annotate every attribute ClassVar.
 ignore = ["RUF012"]
 
+[tool.ruff.lint.isort]
+# Name the project package, instead of a reliance on the same-package detection.
+# That detection needs an `__init__.py` beside the file it sorts, and a test
+# directory has none, so a test module that imports the project would sort that
+# import into the third-party block. Its correct place in that block depends on
+# where the project name falls alphabetically, so the same file would pass or fail
+# the lint by the project name alone.
+known-first-party = ["{{ cookiecutter.project_slug }}"]
+
 [tool.ruff.lint.mccabe]
 max-complexity = 12
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/api_errors.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/api_errors.py
@@ -1,0 +1,127 @@
+"""JSON error responses for API paths.
+
+The SPA catch-all in `common.urls` renders the built `index.html` for any
+unmatched path that ends with a slash. Without the route and the middleware in
+this module, an API path answers with HTML:
+
+- An unknown API path matches the catch-all and answers 200 with the SPA bundle.
+  A client sees success for a route that does not exist.
+- An unhandled exception in an API view answers with Django's HTML error page.
+
+Both bodies are useless to an API client, which expects JSON. The route and the
+middleware here answer with the same JSON shape that
+`rest_framework.views.exception_handler` uses, so a client needs no special case.
+
+The middleware sits below DRF, and it does not compete with DRF. DRF catches an
+exception inside `dispatch`, gives it to `EXCEPTION_HANDLER`, and returns a
+`Response`. No exception leaves such a view, so Django never calls
+`process_exception` for it. The middleware sees only the exceptions that DRF
+re-raises, which are the ones that `exception_handler` returns `None` for. A
+custom `EXCEPTION_HANDLER` therefore keeps priority, and the middleware cannot
+mask it.
+"""
+
+import logging
+
+from django.conf import settings
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.http import Http404, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework import exceptions as drf_exceptions
+
+# Django writes its own request errors to this logger, whose parent `django` logger
+# `LOGGING` configures. This module logs an exception that Django would otherwise log
+# there, so it uses the same name to keep one channel for request failures.
+logger = logging.getLogger("django.request")
+
+API_PATH_PREFIX = "/api/"
+
+# Take each message from DRF, because DRF answers almost every error on an API path.
+# A copy of the text here can drift away from DRF at the next upgrade. `str` resolves
+# the lazy translation once, at import, so a response body and a test compare equal.
+NOT_FOUND_DETAIL = str(drf_exceptions.NotFound.default_detail)
+PERMISSION_DENIED_DETAIL = str(drf_exceptions.PermissionDenied.default_detail)
+SERVER_ERROR_DETAIL = str(drf_exceptions.APIException.default_detail)
+
+
+def _is_api_path(request):
+    return request.path_info.startswith(API_PATH_PREFIX)
+
+
+@csrf_exempt
+def api_not_found(request, *args, **kwargs):
+    """Answer 404 with a JSON body for an unmatched API path.
+
+    This view is the last API route. Every real API route is declared before it,
+    so a request that arrives here asks for a path that does not exist.
+
+    The view is CSRF exempt because `CsrfViewMiddleware` runs before it. Without
+    the exemption, a POST to an unknown API path answers 403 with an HTML body,
+    which is the failure this module removes. The view changes no state, so the
+    exemption adds no risk.
+    """
+    return JsonResponse({"detail": NOT_FOUND_DETAIL}, status=404)
+
+
+class ApiJsonErrorMiddleware:
+    """Turn an unhandled exception on an API path into a JSON 500.
+
+    Keep this middleware in the base `MIDDLEWARE` list, above the Rollbar
+    middleware that `settings` appends. Django calls `process_exception` from the
+    bottom of the list upwards, so Rollbar reports the exception before this
+    middleware builds the response.
+
+    Django logs an unhandled exception to `django.request` only when the
+    exception leaves the middleware chain. This middleware returns a response, so
+    it must log the traceback itself.
+
+    A `handler500` function is not enough: Django bypasses `handler500` when
+    `DEBUG` is true, so a local run and a review app would keep the HTML page.
+
+    Django calls `process_exception` before it turns `Http404` and
+    `PermissionDenied` into their own responses, so this middleware must map those
+    two itself. Without the map, a missing object and a denial both answer 500,
+    which reports a client error as a server fault. DRF maps both inside
+    `dispatch`, so the map guards a plain Django view under `/api/`.
+    """
+
+    # Status and body for an exception that carries its own meaning. Any other
+    # exception is a real fault and answers 500.
+    _MAPPED_EXCEPTIONS = (
+        (Http404, 404, NOT_FOUND_DETAIL),
+        (PermissionDenied, 403, PERMISSION_DENIED_DETAIL),
+    )
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        if not _is_api_path(request):
+            # Let Django and the SPA keep their current behaviour.
+            return None
+
+        for exception_type, status, detail in self._MAPPED_EXCEPTIONS:
+            if isinstance(exception, exception_type):
+                return JsonResponse({"detail": detail}, status=status)
+
+        # SuspiciousOperation and its subclasses keep Django's own handling, which
+        # answers 400 and logs to django.security.
+        if isinstance(exception, SuspiciousOperation):
+            return None
+
+        logger.error(
+            "Unhandled exception in API view: %s %s",
+            request.method,
+            request.path_info,
+            exc_info=exception,
+        )
+
+        body = {"detail": SERVER_ERROR_DETAIL}
+        if settings.DEBUG:
+            # Keep the error visible to a developer, who no longer gets the
+            # Django technical error page for an API call.
+            body["exception"] = repr(exception)
+        return JsonResponse(body, status=500)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/tests/test_api_errors.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/tests/test_api_errors.py
@@ -1,0 +1,342 @@
+"""Tests for the JSON error responses on API paths.
+
+See `common.api_errors`. Two failure classes used to answer HTML: an unknown API
+path fell through to the SPA catch-all, and an unhandled exception rendered a
+Django HTML error page.
+"""
+
+from unittest import mock
+
+import pytest
+from django.conf import settings as django_settings
+from django.core.exceptions import PermissionDenied, SuspiciousOperation
+from django.http import Http404, JsonResponse
+from django.test import Client, override_settings
+from django.test.client import RequestFactory
+from django.urls import re_path
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import AllowAny
+from rest_framework.response import Response
+from rest_framework.views import exception_handler
+
+from {{ cookiecutter.project_slug }}.common.api_errors import (
+    NOT_FOUND_DETAIL,
+    PERMISSION_DENIED_DETAIL,
+    SERVER_ERROR_DETAIL,
+    ApiJsonErrorMiddleware,
+)
+from {{ cookiecutter.project_slug }}.urls import urlpatterns as real_urlpatterns
+
+JSON_CONTENT_TYPE = "application/json"
+HTML_CONTENT_TYPE = "text/html"
+ROLLBAR_MIDDLEWARE = "rollbar.contrib.django.middleware.RollbarNotifierMiddleware"
+# Build the dotted path from the class, instead of a second copy of the string that
+# `settings` holds. A copy could drift, and the test below compares this path with
+# the `MIDDLEWARE` entry, which only tests something if the two come from
+# different places.
+API_JSON_ERROR_MIDDLEWARE = (
+    f"{ApiJsonErrorMiddleware.__module__}.{ApiJsonErrorMiddleware.__qualname__}"
+)
+PROCESS_EXCEPTION = f"{API_JSON_ERROR_MIDDLEWARE}.process_exception"
+CUSTOM_HANDLER_DETAIL = "handled by the custom handler"
+
+
+# ---- Views that raise, for the urlconf below ----
+
+
+def _raise_boom(request):
+    raise RuntimeError("boom")
+
+
+def _raise_not_found(request):
+    raise Http404("no such thing")
+
+
+def _raise_permission_denied(request):
+    raise PermissionDenied("nope")
+
+
+def _raise_suspicious(request):
+    raise SuspiciousOperation("bad request")
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def _raise_drf_validation_error(request):
+    raise ValidationError({"some_field": ["Must be a number."]})
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def _raise_runtime_error_in_a_drf_view(request):
+    raise RuntimeError("boom")
+
+
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def _fail_during_render(request):
+    # JSONRenderer runs after the view returns, which is outside DRF's dispatch,
+    # so DRF cannot map this failure.
+    return Response({"value": object()})
+
+
+def _handler_that_answers_everything(exc, context):
+    """A custom EXCEPTION_HANDLER that also answers for a non-DRF exception."""
+    response = exception_handler(exc, context)
+    if response is None:
+        return Response({"detail": CUSTOM_HANDLER_DETAIL}, status=500)
+    response.data["handled_by"] = "custom"
+    return response
+
+
+# A urlconf that adds the views above. `override_settings(ROOT_URLCONF=__name__)`
+# points Django at this module, so the real routes stay available. The real routes come
+# from the root urlconf, not from `common.urls` alone, so the probe runs against the
+# same route order that a deploy uses. Each probe route must precede the `^api/` catch
+# that the real routes end with, or the catch answers 404 and the probe never runs.
+urlpatterns = [
+    re_path(r"^api/probe-boom/$", _raise_boom),
+    re_path(r"^api/probe-not-found/$", _raise_not_found),
+    re_path(r"^api/probe-denied/$", _raise_permission_denied),
+    re_path(r"^api/probe-suspicious/$", _raise_suspicious),
+    re_path(r"^api/probe-drf-validation/$", _raise_drf_validation_error),
+    re_path(r"^api/probe-drf-runtime/$", _raise_runtime_error_in_a_drf_view),
+    re_path(r"^api/probe-render-failure/$", _fail_during_render),
+    *real_urlpatterns,
+]
+
+
+# ---- An unknown API path ----
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/api/does-not-exist/", id="trailing-slash"),
+        # Without the slashless pattern, CommonMiddleware appends a slash and
+        # redirects the client into the SPA bundle.
+        pytest.param("/api/does-not-exist", id="no-trailing-slash"),
+        pytest.param("/api/deep/does/not/exist/", id="nested"),
+    ],
+)
+def test_unknown_api_path_answers_json_404(client, path):
+    response = client.get(path)
+
+    assert response.status_code == 404
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"detail": NOT_FOUND_DETAIL}
+
+
+def test_post_to_an_unknown_api_path_answers_json_404_with_csrf_enforced():
+    """CsrfViewMiddleware runs before the view, so without the exemption a POST to an
+    unknown API path answers 403 with an HTML body, the failure this module removes."""
+    response = Client(enforce_csrf_checks=True).post("/api/does-not-exist/", data={"a": 1})
+
+    assert response.status_code == 404
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"detail": NOT_FOUND_DETAIL}
+
+
+def test_unknown_non_api_path_still_answers_the_spa(client):
+    """The SPA keeps its client-side routing for a path outside /api/."""
+    response = client.get("/some-frontend-route/")
+
+    assert response["Content-Type"].startswith(HTML_CONTENT_TYPE)
+
+
+# ---- A real API route keeps its own answer ----
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        pytest.param("/api/schema/", id="schema"),
+        pytest.param("/api/users/", id="router"),
+        pytest.param("/api/login/", id="view"),
+        # The root urlconf includes `common.urls` last, after `core.urls` and the
+        # chat app, so the catch cannot shadow a route from another app either.
+        pytest.param("/api/chat/system-prompt/", id="other-app"),
+    ],
+)
+def test_a_real_api_route_is_not_swallowed_by_the_api_catch(client, path):
+    """The catch sits after every real route, so a real route still resolves."""
+    response = client.get(path)
+
+    assert response.status_code != 404
+
+
+# ---- An unhandled exception ----
+
+
+@override_settings(ROOT_URLCONF=__name__)
+@pytest.mark.parametrize("debug", [True, False])
+def test_unhandled_exception_on_api_path_answers_json_500(client, settings, debug):
+    """Django bypasses handler500 when DEBUG is true, so only middleware covers both."""
+    settings.DEBUG = debug
+
+    # The middleware handles the exception, so the test client must not re-raise.
+    client.raise_request_exception = False
+    response = client.get("/api/probe-boom/")
+
+    assert response.status_code == 500
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json()["detail"] == SERVER_ERROR_DETAIL
+    if debug:
+        assert "boom" in response.json()["exception"]
+    else:
+        assert "exception" not in response.json()
+
+
+# ---- An exception that carries its own meaning keeps its own status ----
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_http404_in_an_api_view_answers_json_404(client):
+    """Django calls process_exception before it maps Http404, so the middleware must
+    map it. Without the map a missing object reports as a server fault."""
+    client.raise_request_exception = False
+    response = client.get("/api/probe-not-found/")
+
+    assert response.status_code == 404
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"detail": NOT_FOUND_DETAIL}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_permission_denied_in_an_api_view_answers_json_403(client):
+    """A denial must not report as a server fault."""
+    client.raise_request_exception = False
+    response = client.get("/api/probe-denied/")
+
+    assert response.status_code == 403
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"detail": PERMISSION_DENIED_DETAIL}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_suspicious_operation_keeps_djangos_handling(client):
+    """Django answers 400 and logs to django.security, so the middleware steps aside."""
+    client.raise_request_exception = False
+    response = client.get("/api/probe-suspicious/")
+
+    assert response.status_code == 400
+
+
+# ---- The layering between DRF and the middleware ----
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_drf_exception_keeps_its_own_response(client):
+    """DRF answers inside `dispatch`, so no exception reaches the middleware.
+
+    Without this test the middleware could start to swallow a DRF error and report
+    a client mistake as a server fault.
+    """
+    with mock.patch(
+        PROCESS_EXCEPTION, autospec=True, side_effect=ApiJsonErrorMiddleware.process_exception
+    ) as spy:
+        response = client.get("/api/probe-drf-validation/")
+
+    assert response.status_code == 400
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"some_field": ["Must be a number."]}
+    assert not spy.called, "DRF handled the exception, so the middleware must stay out."
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_drf_view_re_raises_a_real_fault_to_the_middleware(client, settings):
+    """The other half of the layering: the default handler returns None for a fault.
+
+    DRF then re-raises, and the middleware answers.
+    """
+    settings.DEBUG = False
+    client.raise_request_exception = False
+
+    with mock.patch(
+        PROCESS_EXCEPTION, autospec=True, side_effect=ApiJsonErrorMiddleware.process_exception
+    ) as spy:
+        response = client.get("/api/probe-drf-runtime/")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": SERVER_ERROR_DETAIL}
+    assert spy.called
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_failure_during_response_render_answers_json_500(client, settings):
+    """The renderer runs after `dispatch`, so only the middleware can answer here."""
+    settings.DEBUG = False
+    client.raise_request_exception = False
+
+    response = client.get("/api/probe-render-failure/")
+
+    assert response.status_code == 500
+    assert response["Content-Type"].startswith(JSON_CONTENT_TYPE)
+    assert response.json() == {"detail": SERVER_ERROR_DETAIL}
+
+
+@override_settings(ROOT_URLCONF=__name__)
+def test_custom_drf_exception_handler_keeps_priority(client, settings):
+    """The middleware is a net below DRF, and it cannot mask a custom handler.
+
+    A custom `EXCEPTION_HANDLER` that answers for a non-DRF exception stops the
+    exception inside `dispatch`, so the middleware never runs.
+    """
+    settings.DEBUG = False
+    settings.REST_FRAMEWORK = dict(
+        settings.REST_FRAMEWORK,
+        EXCEPTION_HANDLER=f"{__name__}._handler_that_answers_everything",
+    )
+    client.raise_request_exception = False
+
+    with mock.patch(
+        PROCESS_EXCEPTION, autospec=True, side_effect=ApiJsonErrorMiddleware.process_exception
+    ) as spy:
+        response = client.get("/api/probe-drf-runtime/")
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": CUSTOM_HANDLER_DETAIL}
+    assert not spy.called, "The custom handler answered, so the middleware must stay out."
+
+
+# ---- The middleware in isolation ----
+
+
+def test_middleware_ignores_a_non_api_path():
+    """Django and the SPA keep their current error handling outside /api/."""
+    middleware = ApiJsonErrorMiddleware(lambda request: None)
+    request = RequestFactory().get("/some-frontend-route/")
+
+    assert middleware.process_exception(request, RuntimeError("boom")) is None
+
+
+def test_middleware_handles_an_api_path():
+    middleware = ApiJsonErrorMiddleware(lambda request: None)
+    request = RequestFactory().get("/api/anything/")
+
+    response = middleware.process_exception(request, RuntimeError("boom"))
+
+    assert isinstance(response, JsonResponse)
+    assert response.status_code == 500
+
+
+def test_middleware_runs_after_rollbar_reports():
+    """Django calls process_exception from the bottom of MIDDLEWARE upwards.
+
+    Rollbar must therefore sit below this middleware, so that it reports the
+    exception before this middleware turns it into a response.
+
+    `settings` appends the Rollbar middleware only when a Rollbar token is set, and
+    the test settings hold none. So this test asserts against the list that
+    `settings` builds, and reproduces the append. A conditional check would pass
+    without an assertion during a normal test run.
+    """
+    assert API_JSON_ERROR_MIDDLEWARE in django_settings.MIDDLEWARE
+    assert django_settings.MIDDLEWARE[-1] == API_JSON_ERROR_MIDDLEWARE, (
+        "The middleware must stay last in the base list, because settings appends "
+        "the Rollbar middleware after it."
+    )
+
+    with_rollbar = [*django_settings.MIDDLEWARE, ROLLBAR_MIDDLEWARE]
+    assert with_rollbar.index(API_JSON_ERROR_MIDDLEWARE) < with_rollbar.index(ROLLBAR_MIDDLEWARE)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/common/urls.py
@@ -12,6 +12,7 @@ from rest_framework import permissions
 from rest_framework_nested import routers
 
 from {{ cookiecutter.project_slug }}.common import views as common_views
+from {{ cookiecutter.project_slug }}.common.api_errors import api_not_found
 
 router = routers.SimpleRouter()
 if settings.DEBUG:
@@ -51,6 +52,11 @@ if settings.IN_REVIEW:
     ]
 
 urlpatterns += [
+    # Last API route. Every real API route is declared above, so an API path that
+    # reaches here does not exist and must answer JSON, never the SPA bundle. The
+    # pattern has no trailing slash, so it also catches a slashless path that
+    # CommonMiddleware would otherwise redirect into the SPA.
+    re_path(r"^api/", api_not_found),
     path("", common_views.index),
     re_path(r".*/$", common_views.index),
 ]

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_cleanup_inactive_users.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_cleanup_inactive_users.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
+
 from {{ cookiecutter.project_slug }}.core.models import User
 
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -109,9 +109,11 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
             STATIC_ROOT,
-            os.path.join(
-                BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"
-            ),  # Swagger template override
+            # Swagger template override. Keep this comment on its own line: a
+            # trailing comment holds the call open across lines, and ruff format
+            # then joins or splits it by the length of the project name, so the
+            # generated project would fail its own format check at a short name.
+            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"),
         ],
         "APP_DIRS": True,  # this setting must come after "DIRS"!
         "OPTIONS": {

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -88,6 +88,10 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    # Keep last in this list. The Rollbar middleware is appended below, and
+    # Django calls process_exception from the bottom upwards, so Rollbar reports
+    # an exception before this middleware turns it into a JSON response.
+    "{{ cookiecutter.project_slug }}.common.api_errors.ApiJsonErrorMiddleware",
 ]
 
 OLD_PASSWORD_FIELD_ENABLED = True


### PR DESCRIPTION
Stacked on #534. Merge that PR first.

## Problem

Two failures on an `/api/` path answered with HTML, which is useless to an API client.

**1. An unknown API path answered 200 with the SPA bundle.** The catch-all at the end of `common/urls.py` renders the React `index.html` for any unmatched path that ends with a slash, so a client saw success for a route that does not exist. A path without a trailing slash was worse: `CommonMiddleware` appended the slash, sent a 301, and the retry hit the SPA.

**2. An unhandled exception answered a Django HTML error page.** `DEBUG` only decides which HTML page you get, so neither mode gives a client JSON.

## Fix

New module `common/api_errors.py`, with an `api_not_found` view and `ApiJsonErrorMiddleware`. Both use the body shape of `rest_framework.views.exception_handler`, so a client needs no special case.

| Case | Status | Body |
| --- | --- | --- |
| Unknown API path | 404 | `{"detail": "Not found."}` |
| `Http404` in an API view | 404 | `{"detail": "Not found."}` |
| `PermissionDenied` in an API view | 403 | `{"detail": "You do not have permission ..."}` |
| Unhandled exception | 500 | `{"detail": "A server error occurred."}` |
| Unhandled exception, `DEBUG` | 500 | the above plus `"exception": "<repr>"` |

- `common/api_errors.py` (new)
- `common/urls.py` — `re_path(r"^api/", api_not_found)` before the SPA catch-all
- `settings.py` — the middleware, last in the base `MIDDLEWARE` list
- `common/tests/test_api_errors.py` (new) — 21 tests

## Design notes

- **Middleware, not `handler500`.** Django bypasses `handler500` when `DEBUG` is true, so a handler would keep the HTML page in a local run and a review app.
- **The `^api/` route has no trailing slash**, so it also catches the slashless path.
- **Route order.** The root urlconf includes `common.urls` last, and the catch sits at the end of that module. So the schema routes, `api-auth/`, every `core` route, and `/api/chat/...` keep working.
- **Rollbar keeps reporting.** Django calls `process_exception` from the bottom of `MIDDLEWARE` upwards, so the middleware stays above the Rollbar middleware that `settings.py` appends.
- **DRF keeps priority.** DRF answers inside `dispatch`, so the middleware sees only what DRF re-raises. A custom `EXCEPTION_HANDLER` therefore still wins.
- **`Http404` and `PermissionDenied` keep their own status.** Django calls `process_exception` before it maps those two, so without the map a missing object and a denial would both answer 500.
- **`SuspiciousOperation` keeps Django's handling**, which answers 400.
- The middleware returns `None` for a non-API path, so Django and the SPA do not change. WebSocket traffic goes through the `URLRouter`, not `MIDDLEWARE`.

## Verification

In a rendered project:

```
pytest .../common/tests/test_api_errors.py -q  ->  21 passed
ruff==0.16.0 check server/                     ->  All checks passed
ruff==0.16.0 format --check server/            ->  all files formatted
scripts/test-template-linting.sh               ->  All linting checks passed
```
