### PR TITLE
Stop the generated project failing its own ruff checks by name length

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -71,6 +71,15 @@ extend-select = ["I", "C90"]
 # not bugs, so silence the rule rather than annotate every attribute ClassVar.
 ignore = ["RUF012"]
 
+[tool.ruff.lint.isort]
+# Name the project package, instead of a reliance on the same-package detection.
+# That detection needs an `__init__.py` beside the file it sorts, and a test
+# directory has none, so a test module that imports the project would sort that
+# import into the third-party block. Its correct place in that block depends on
+# where the project name falls alphabetically, so the same file would pass or fail
+# the lint by the project name alone.
+known-first-party = ["{{ cookiecutter.project_slug }}"]
+
 [tool.ruff.lint.mccabe]
 max-complexity = 12
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_cleanup_inactive_users.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_cleanup_inactive_users.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 from django.core.management import call_command
 from django.utils import timezone
+
 from {{ cookiecutter.project_slug }}.core.models import User
 
 

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -109,9 +109,11 @@ TEMPLATES = [
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         "DIRS": [
             STATIC_ROOT,
-            os.path.join(
-                BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"
-            ),  # Swagger template override
+            # Swagger template override. Keep this comment on its own line: a
+            # trailing comment holds the call open across lines, and ruff format
+            # then joins or splits it by the length of the project name, so the
+            # generated project would fail its own format check at a short name.
+            os.path.join(BASE_DIR, "{{ cookiecutter.project_slug }}", "client", "templates"),
         ],
         "APP_DIRS": True,  # this setting must come after "DIRS"!
         "OPTIONS": {


### PR DESCRIPTION
## Problem

A generated project failed its own ruff checks because of the project name.

**1. `ruff format --check` failed at a short name.** In `server/<slug>/settings.py`, a trailing comment held the `os.path.join` call for the Swagger template directory open across lines. Ruff format then joined or split that call by the length of the name:

```
project_name "My Project" ->  passes
project_name "Acme"       ->  1 file would be reformatted
```

**2. `ruff check` sorted a test import by the project name.** Ruff's same-package detection needs an `__init__.py` beside the file it sorts. A test directory has none, so a test module that imports the project sorts that import into the third-party block. Its place in that block depends on where the name falls alphabetically, so the same file passes or fails by the name alone.

## Fix

- `settings.py` — the comment moves onto its own line.
- `pyproject.toml` — `known-first-party` names the project package.
- `core/tests/test_cleanup_inactive_users.py` — the project import moves into its own block, to match the new sort.

## Verification

Rendered the template at three names and checked each rendered project:

| Project name | `ruff check` | `ruff format --check` |
| --- | --- | --- |
| My Project | pass | pass |
| Zulu App | pass | pass |
| Acme | pass | pass |

`scripts/test-template-linting.sh` also passes.

## Out of scope

A name longer than about 30 characters still fails `ruff format --check` on other lines: the `SERVER_EMAIL` default and two `LOGGING` entries in `settings.py`, an import in `core/admin.py`, and one in `core/tests.py`. That needs its own pass.
