### PR TITLE
fix: bump pyasn1 to >=0.6.4 (GHSA-hm4w-wwcw-mr6r, GHSA-8ppf-4f7h-5ppj)

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "rollbar>=1.2.0",
     "twilio>=9.4.6",
     "whitenoise==5.3.0",
-    "pyasn1>=0.6.3",
+    "pyasn1>=0.6.4",
     "pyopenssl>=26.0.0",
     "pyjwt>=2.13.0",
     "ujson>=5.13.0",

--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -2033,7 +2033,7 @@ requires-dist = [
     { name = "pre-commit", specifier = "==4.5.*" },
     { name = "premailer", specifier = ">=3.10.0" },
     { name = "psycopg2-binary", specifier = "==2.9.*" },
-    { name = "pyasn1", specifier = ">=0.6.3" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic-ai", specifier = ">=1.84.0" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pyopenssl", specifier = ">=26.0.0" },


### PR DESCRIPTION
## Dependabot security fix: pyasn1 (2 HIGH alerts)

### Fixed alerts

| Alert | Package | Severity | GHSA ID | Summary |
|-------|---------|----------|---------|---------|
| #813 | pyasn1 | HIGH | GHSA-8ppf-4f7h-5ppj | Quadratic complexity in OBJECT IDENTIFIER and RELATIVE-OID processing |
| #814 | pyasn1 | HIGH | GHSA-hm4w-wwcw-mr6r | Uncontrolled resource consumption when converting decoded REAL values |

### What changed

- `{{cookiecutter.project_slug}}/pyproject.toml`: raised pyasn1 lower bound from `>=0.6.3` to `>=0.6.4`
- `{{cookiecutter.project_slug}}/uv.lock`: updated declared specifier to match (resolved version was already 0.6.4)

### Verification

The lock file already resolved pyasn1 to 0.6.4 before this change. The pyasn1 0.6.4 release (2026-07-09) is confirmed on PyPI. The specifier change aligns the declared minimum with the fixed release and prevents downgrade to 0.6.3. No transitive dependency requires pyasn1 < 0.6.4.
