### PR TITLE
Scope brace-expansion overrides per minimatch major; bump xcode uuid

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -1923,6 +1923,15 @@
         "fingerprint": "bin/cli.js"
       }
     },
+    "node_modules/@expo/fingerprint/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@expo/fingerprint/node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -1945,16 +1954,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/fingerprint/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@expo/fingerprint/node_modules/semver": {
@@ -2092,6 +2091,15 @@
         "json5": "^2.2.3"
       }
     },
+    "node_modules/@expo/metro-config/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@expo/metro-config/node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -2141,16 +2149,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@expo/metro-config/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@expo/osascript": {
@@ -4450,6 +4448,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@typescript-eslint/utils/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/@typescript-eslint/utils/node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -4464,17 +4472,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/utils/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/@typescript-eslint/utils/node_modules/semver": {
@@ -5506,6 +5503,16 @@
       },
       "engines": {
         "node": ">= 5.10.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
       }
     },
     "node_modules/braces": {
@@ -7701,6 +7708,15 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/expo/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
     "node_modules/expo/node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -7723,16 +7739,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/expo/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/expo/node_modules/picomatch": {
@@ -8273,6 +8279,27 @@
       "license": "BSD-2-Clause",
       "peer": true
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/glob/node_modules/minimatch": {
       "version": "10.2.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -8286,22 +8313,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/glob/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/globalthis": {
@@ -10139,16 +10150,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
       }
     },
     "node_modules/minimist": {
@@ -13520,6 +13521,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -13917,13 +13931,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/xcode/node_modules/uuid": {
-      "version": "7.0.3",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/xdate": {

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -130,7 +130,18 @@
     "node-forge": ">=1.4.0",
     "undici": ">=6.27.0",
     "ws": ">=6.2.4",
-    "brace-expansion": ">=1.1.13 <2.0.0",
+    "minimatch@3": {
+      "brace-expansion": ">=1.1.18 <2.0.0"
+    },
+    "minimatch@9": {
+      "brace-expansion": ">=2.1.4 <3.0.0"
+    },
+    "minimatch@10": {
+      "brace-expansion": ">=5.0.8"
+    },
+    "xcode": {
+      "uuid": ">=11.1.1 <12.0.0"
+    },
     "tar": ">=7.5.21",
     "fast-uri": ">=4.1.1",
     "postcss": ">=8.5.18",


### PR DESCRIPTION
## What This Does

Clears Dependabot alerts #819 (HIGH, GHSA-mh99-v99m-4gvg, brace-expansion) and #679 (MEDIUM, GHSA-w5hq-g745-h8pq, uuid) in the mobile React Native client.

The brace-expansion advisory range is `<=5.0.7`. It covers every published major, so no single version satisfies it for the whole tree. Each minimatch major also consumes brace-expansion with a different export shape:

| minimatch | how it imports brace-expansion | needs |
|---|---|---|
| 3.1.5 | `require('brace-expansion')` as a function | 1.x |
| 9.0.9 | `__importDefault(require('brace-expansion'))` | 2.x |
| 10.2.4 | `import { expand } from 'brace-expansion'` (named) | 5.x |

The previous override, `brace-expansion: ">=1.1.13 <2.0.0"`, forced 1.x onto minimatch 10.x. Version 1.x has no named `expand` export, so this was already a run-time defect on `main`, not only a stale alert. PR #536 skipped both alerts because a global override cannot satisfy the three majors at the same time.

This change replaces the global override with per-consumer overrides. Every minimatch major now gets a brace-expansion that matches its import shape **and** contains the CVE-2026-14257 length guard. The fix is backported: 1.1.18, 2.1.4 and 5.0.9 all bound expansion with `EXPANSION_MAX_LENGTH`.

`xcode@3.0.1` declares `uuid ^7.0.3` and calls `uuid.v4()` through `require()`. uuid 12+ is ESM-only, and an unbounded `>=11.1.1` floated the install to 14.0.1. The override therefore holds the consumer inside 11.x.

## Note for reviewers

Check that the run-time defect is real, because it is the reason to change the override instead of raising it. On `main`, Expo's own ignore-path helper fails on any brace pattern:

```
$ node -e "require('@expo/fingerprint/build/utils/Path.js').isIgnoredPath('node_modules/foo.js', ['**/{node_modules,build}/**'])"
TypeError: (0 , brace_expansion_1.expand) is not a function     # main
-> true                                                          # this branch
```

Verified in `node:22-bookworm` on a project generated from this template with `include_mobile: y`, after a real `npm install` (1219 packages):

- Resolved pairs, each with the CVE guard: minimatch 3.1.5 -> 1.1.18, minimatch 9.0.9 -> 2.1.4, minimatch 10.2.4 -> 5.0.9, uuid 11.1.1.
- `npm run lint:eslint` exits 0. It exercises the minimatch 3.x and 9.x paths.
- `npm run lint:tslint` reports no errors.
- DoS probe: a 6,000,000-character pattern truncates below the 4,000,000-character cap in 19 ms, with no OOM.
- `npm audit` no longer reports uuid.
- Template suite: 7 passed, 1 skipped.

Two points to note. First, `npm audit` still lists brace-expansion, because 1.1.18 and 2.1.4 sit inside the `<=5.0.7` advisory range even though they carry the backported fix; only the 5.x line is outside the range. Forcing 5.x everywhere is not an option, since it breaks ESLint 8.57's minimatch 3.x with the mirror-image error (`expand is not a function`). Dependabot may keep #819 open for this reason.

Second, `npm run format:check` reports 3 files and `tsc` reports a missing `@expo/vector-icons`. Both are identical on `main` in a baseline install and are unrelated to this change.

Scope is limited to what was verified. Left out: react-router alerts #820/#821/#822, which need a v6 to v7 major upgrade with no 6.x patch published; the pytest and idna alerts, which are separate ecosystems; and the pyasn1 and daphne alerts (#813/#814/#806/#808), which point at `my_project/uv.lock`, a generated project committed by mistake and already deleted in #501 — the template lock already resolves pyasn1 0.6.4 and daphne 4.2.2.

> Do not merge this PR without human review.