### PR TITLE
Move CVE pins to uv constraint-dependencies

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -36,10 +36,6 @@ dependencies = [
     "requests>=2.33.0",
     "rollbar>=1.2.0",
     "whitenoise==5.3.0",
-    "pyasn1>=0.6.4",
-    "pyopenssl>=26.0.0",
-    "pyjwt>=2.13.0",
-    "ujson>=5.13.0",
 ]
 
 [dependency-groups]
@@ -81,8 +77,15 @@ max-complexity = 12
 fail_under = 60
 
 [tool.uv]
+# Floors for transitive packages, set by past security fixes. A constraint only
+# applies when some other package requires the name, so a dropped dependency
+# chain does not keep an unused package installed.
 constraint-dependencies = [
     "urllib3>=2.7.0",
+    "pyasn1>=0.6.4",
+    "pyopenssl>=26.0.0",
+    "pyjwt>=2.13.0",
+    "ujson>=5.13.0",
     "aiohttp>=3.14.3",
     "cryptography>=50.0.0",
     "virtualenv>=20.36.1",

--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -17,8 +17,12 @@ constraints = [
     { name = "idna", specifier = ">=3.15" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "msgpack", specifier = ">=1.2.1" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pynacl", specifier = ">=1.6.2" },
+    { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "twisted", specifier = ">=26.4.0" },
+    { name = "ujson", specifier = ">=5.13.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
     { name = "virtualenv", specifier = ">=20.36.1" },
 ]
@@ -1638,10 +1642,7 @@ dependencies = [
     { name = "pre-commit" },
     { name = "premailer" },
     { name = "psycopg2-binary" },
-    { name = "pyasn1" },
     { name = "pydantic-ai" },
-    { name = "pyjwt" },
-    { name = "pyopenssl" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-django" },
@@ -1649,7 +1650,6 @@ dependencies = [
     { name = "python-decouple" },
     { name = "requests" },
     { name = "rollbar" },
-    { name = "ujson" },
     { name = "whitenoise" },
 ]
 
@@ -1685,10 +1685,7 @@ requires-dist = [
     { name = "pre-commit", specifier = "==4.5.*" },
     { name = "premailer", specifier = ">=3.10.0" },
     { name = "psycopg2-binary", specifier = "==2.9.*" },
-    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic-ai", specifier = ">=1.84.0" },
-    { name = "pyjwt", specifier = ">=2.13.0" },
-    { name = "pyopenssl", specifier = ">=26.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-django", specifier = ">=4.8.0" },
@@ -1696,7 +1693,6 @@ requires-dist = [
     { name = "python-decouple", specifier = ">=3.8" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "rollbar", specifier = ">=1.2.0" },
-    { name = "ujson", specifier = ">=5.13.0" },
     { name = "whitenoise", specifier = "==5.3.0" },
 ]
 


### PR DESCRIPTION
## What This Does
Moves four CVE floor pins (`pyasn1>=0.6.4`, `pyopenssl>=26.0.0`, `pyjwt>=2.13.0`, `ujson>=5.13.0`) from `[project] dependencies` to `[tool.uv] constraint-dependencies`.

Commit 0ff6740 (#479) added the four as direct dependencies to force CVE-fixed versions of transitive packages. That predates this project's use of `constraint-dependencies`, which is the correct mechanism for version floors and which later security fixes already use. A direct dependency forces installation even when no other package needs it. A constraint only applies when another package requires the name, so a dropped dependency chain does not keep an unused package installed.

## Note for reviewers
Check the `uv.lock` diff: the four names move from the root package's dependencies to the manifest constraints list, with zero version changes and the same 177 packages. All four stay in the lock as transitives of live consumers (`pyjwt` via `mcp`, `pyasn1` via `pyasn1-modules`, `pyopenssl` via `twisted[tls]`, `ujson` via `autobahn`), and each resolved version meets its floor. `uv lock --check` passes in a generated project.