### PR TITLE
fix: bump undici to 7.29.0 in mobile client (5 CVEs)

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -13827,9 +13827,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -140,7 +140,7 @@
     "tmp": ">=0.2.6",
     "@babel/helpers": ">=7.26.10",
     "node-forge": ">=1.4.0",
-    "undici": ">=6.27.0",
+    "undici": ">=7.29.0",
     "ws": ">=6.2.4",
     "minimatch@3": {
       "brace-expansion": ">=1.1.18 <2.0.0"


### PR DESCRIPTION
## What This Does
Raises the npm `overrides` floor for `undici` from `>=6.27.0` to `>=7.29.0` in the mobile React Native template, which closes the five open undici Dependabot alerts (#831–#835).
All five alerts point at the mobile client's lock file. Alert #832 is high severity (GHSA-4cwx-7wf7-3272); the other four are medium. Each advisory gives the same vulnerable range (`>=7.0.0 <7.29.0`) and the same fixed version (7.29.0), so one floor raise closes all five. `undici` enters the tree through the existing security override for `@expo/cli`.

## Note for reviewers
Check the regenerated lock file. A JSON diff of it shows zero packages added or removed and exactly one version change (undici 7.28.0 → 7.29.0), and the `{{ cookiecutter.project_slug }}` placeholder stays in both name fields. In a generated project (`rn_template` config), `npm ci`, `npm run lint:tslint`, and `npm run lint:eslint` all exit 0 — the same commands the Lint_Mobile CI job runs.