### PR TITLE
Bump js-yaml to 3.15.1 and 4.3.1 in both clients (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -1615,28 +1615,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/type-fest": {
       "version": "0.20.2",
       "license": "(MIT OR CC0-1.0)",
@@ -2373,28 +2351,6 @@
         "excpretty": "build/cli.js"
       }
     },
-    "node_modules/@expo/xcpretty/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "license": "Apache-2.0",
@@ -2484,9 +2440,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7011,28 +6967,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/eslint/node_modules/type-fest": {
       "version": "0.20.2",
       "license": "(MIT OR CC0-1.0)",
@@ -9370,6 +9304,28 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsc-safe-url": {
       "version": "0.2.4",

--- a/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
@@ -765,29 +765,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5164,9 +5141,9 @@
       }
     },
     "node_modules/eslint-prettier-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6911,6 +6888,29 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/jsdom": {
       "version": "27.4.0",


### PR DESCRIPTION
## What This Does

Moves js-yaml to 3.15.1 and 4.3.1 in the web and mobile client lock files, to clear GHSA-5p4m-2wfm-xmqj (high, quadratic CPU consumption in `!!omap` resolution).

The advisory applies to js-yaml `>=3.0.0 <3.15.1` and `>=4.0.0 <4.3.1`. Both clients resolved vulnerable versions. The maintainers released the fix as a patch inside each major, so the design decision is to take the patch and add no override. Every consumer already declares a caret range that accepts it, so no manifest changes:

| Client | Consumer | Declares | Was | Now |
| --- | --- | --- | --- | --- |
| web | `@eslint/eslintrc` | `^4.1.0` | 4.3.0 | 4.3.1 |
| web | `eslint` (nested in `eslint-prettier-config`) | `^3.13.1` | 3.15.0 | 3.15.1 |
| mobile | `@eslint/eslintrc`, `eslint`, `@expo/xcpretty` | `^4.1.0` | 4.3.0 | 4.3.1 |
| mobile | `@istanbuljs/load-nyc-config` | `^3.13.1` | 3.15.0 | 3.15.1 |

This keeps the decision in commit 706a0ea, which removed an unbounded js-yaml override because it let npm climb to a major 5 that no consumer requests. The fix stays inside each requested major, so major 5 is still absent from both trees.

The diff removes more lines than it adds because npm hoists the four separate 4.3.0 copies into one `node_modules/js-yaml` at 4.3.1.

## Note for reviewers

The web client still reports one high alert, brace-expansion GHSA-mh99-v99m-4gvg and GHSA-rgw5-rvv9-x895 at 1.1.16. It is not in this change. It is a separate cluster: it needs a change to the per-major override structure in both manifests, not a lock refresh. Confirm you agree it is out of scope here.

Verified on a project rendered from this template, in a `node:22-bookworm` container, because a lock file made on macOS can omit Linux binaries:

- `npm ci` in both clients. js-yaml on disk after install: `node_modules/js-yaml` 4.3.1 and the nested 3.15.1 copy in each client.
- Web: `npm run tslint` (tsc) passes, `npm run eslint` passes, `npm run build` passes. ESLint is the consumer of js-yaml through `@eslint/eslintrc`, so this exercises the changed package.
- Mobile: `npm run lint:tslint` passes, `npm run lint:eslint` passes, and `npm audit` reports 0 vulnerabilities.
- Web `npm test` (vitest) is unchanged from the baseline before this change: 1 test passes and 5 suites fail, because vitest collects the Playwright specs under `tests/e2e`. I ran the baseline in the same container to confirm the identical result.
- Re-rendered the project from the modified template; both lock files are byte-identical to the ones I tested.