### PR TITLE
fix(db): do not hold persistent connections under ASGI

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -174,7 +174,16 @@ else:
             "USER": config("DB_USER"),
             "PASSWORD": config("DB_PASS", default=""),
             "HOST": config("DB_HOST"),
-            "CONN_MAX_AGE": 600,
+            # 0, not a persistent connection, because this project serves
+            # ASGI (daphne, with channels). Django closes old connections on
+            # the request_started and request_finished signals, and neither
+            # fires for a WebSocket. A long-lived socket therefore has no
+            # request boundary to release a connection on. Channels compensates
+            # by calling close_old_connections() inside database_sync_to_async,
+            # but that helper only closes once CONN_MAX_AGE has elapsed -- so a
+            # large value disables the one cleanup hook the socket path has
+            # left.
+            "CONN_MAX_AGE": 0,
         },
     }
 #

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/test_settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/test_settings.py
@@ -22,7 +22,14 @@ if config("CI", False):
             "USER": config("TEST_DB_USER"),
             "PASSWORD": config("TEST_DB_PASS", default=""),
             "HOST": config("DB_HOST"),
-            "CONN_MAX_AGE": 600,
+            # 0 so connections close after each use. A test suite must not
+            # reuse connections: `database_sync_to_async` runs every async
+            # database call on one process-wide executor thread, and
+            # `channels.db` calls close_old_connections() around each call to
+            # clean up after it -- but that helper only closes once
+            # CONN_MAX_AGE has elapsed, so a large value made it a no-op for
+            # the whole run and leaked connections across tests.
+            "CONN_MAX_AGE": 0,
         },
     }
 


### PR DESCRIPTION
## Why

Both the app settings and the test settings set `CONN_MAX_AGE = 600`. Generated
projects serve **ASGI** — `daphne` in the Procfile, `ASGI_APPLICATION` set,
`channels_redis` configured — so persistent connections are a poor fit.

Django closes old connections on the `request_started` and `request_finished`
signals. **Neither fires for a WebSocket.** A long-lived socket therefore has no
request boundary to release a connection on.

Channels compensates by calling `close_old_connections()` inside
`database_sync_to_async` — but that helper only closes a connection once
`CONN_MAX_AGE` has elapsed. So a 600 s value disables the one cleanup hook the
socket path has left.

## Changes

| File | Change |
|---|---|
| `settings.py:177` | `CONN_MAX_AGE` 600 → 0 |
| `test_settings.py:25` | `CONN_MAX_AGE` 600 → 0 |

The **test settings are the clearer bug**. A suite must not reuse connections
across tests: every async database call runs on one process-wide executor
thread, and at 600 s that thread's connection survives the entire run.

## Scope, stated plainly

I found this while debugging flaky async WebSocket tests in a project generated
from this template. **This change did not fix that flakiness on its own**, and I
am not offering it as a cure. The flake has a separate, still-unidentified
cause — with `CONN_MAX_AGE = 0` applied, teardown still reports
`database "test_..._gwN" is being accessed by other users`.

The change is correct on its own terms regardless.

## Note for anyone auditing a generated project

This branch only applies when `DB_NAME`/`DB_USER`/`DB_HOST` are configured
directly. A deployment that sets `DATABASE_URL` takes the `dj_database_url`
branch above it, which already defaults `CONN_MAX_AGE` to 0 — so many deployed
projects were never affected by the 600, while local development and
direct-config deployments were.