### PR TITLE
Validate spekk specs in pre-commit and CI

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/specs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/specs.yml
@@ -1,0 +1,34 @@
+name: Specs
+on: [push]
+jobs:
+  Validate_Specs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stay green in a project that has not adopted spekk, without
+      # downloading a binary it will not use.
+      - name: Look for specs
+        id: check
+        run: |
+          if [ -d specs ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install spekk
+        if: steps.check.outputs.found == 'true'
+        env:
+          # Pinned on purpose: without it the install takes the latest
+          # release, and a stricter validator would turn this repository red
+          # with no change on its side.
+          SPEKK_VERSION: v1.22.0
+        run: curl -fsSL https://raw.githubusercontent.com/spekk-ai/spekk-cli/main/install.sh | sh
+
+      # One malformed frontmatter field fails the parse of the whole tree, so
+      # a bad line on the default branch stops every spekk command that
+      # rebuilds the index, for every branch and every user.
+      - name: Validate specs
+        if: steps.check.outputs.found == 'true'
+        run: ~/.local/bin/spekk validate

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -51,6 +51,13 @@ repos:
         files: ^client/.*\.(ts|tsx)$
         pass_filenames: false
 
+  # Spec validation for spekk projects. The hook only runs when a staged file
+  # is under specs/, so a project that does not use spekk never invokes it.
+  - repo: https://github.com/spekk-ai/spekk-cli
+    rev: v1.22.0
+    hooks:
+      - id: spekk-validate
+
   # General hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
## Problem

One malformed frontmatter field fails the parse of the whole spec tree. On the default branch this stops each spekk command that rebuilds the index — `spekk next`, `spekk observer announce`, `spekk query` — on all branches, for all users.

This occurred on a client project. It stopped two scheduled agent runs for a day.

## Change

A generated project gets two checks.

| Check | Catches | Does not catch |
|---|---|---|
| pre-commit hook | The author, before the commit | A new clone before `pre-commit install`; `git commit --no-verify` |
| CI | What the hook missed | Nothing, but only after a push |

Both are inactive until a project adds `specs/`. The hook uses `files: ^specs/`. The workflow looks for `specs/` before it downloads the binary.

Tested with `spekk` absent from `PATH`: the hook reports `Skipped` and the commit succeeds.

`SPEKK_VERSION` is pinned in the workflow. Without a pin, CI takes the latest release, and a stricter validator can fail the repository with no change on its side.

## Blocked

This needs spekk-cli v1.22.0, the release with `.pre-commit-hooks.yaml` (see [spekk-ai/spekk-cli#181](https://github.com/spekk-ai/spekk-cli/pull/181)). An earlier `rev` gives `InvalidManifestError`. Please hold until that release is available.

`uv run pytest tests/`: 7 passed, 1 skipped.