### PR TITLE
Bump nanoid, fix the @xmldom/xmldom override, pin react-native-worklets

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -58,6 +58,7 @@
         "react-native-svg": "15.12.1",
         "react-native-tab-view": "^3.3.4",
         "react-native-web": "^0.21.0",
+        "react-native-worklets": "0.5.1",
         "rn-bounceable": "^1.2.0",
         "tailwind-merge": "^2.6.0",
         "zod": "^3.22.3",
@@ -1396,7 +1397,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
       "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -3144,6 +3144,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.84.1.tgz",
       "integrity": "sha512-NswINguTz0eg1Dc0oGO/1dejXSr6iQaz8/NnCRn5HJdA3dGfqadS7zlYv0YjiWpgKgcW6uENaIEgJOQww0KSpw==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3163,6 +3164,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.84.1.tgz",
       "integrity": "sha512-vorvcvptGxtK0qTDCFQb+W3CU6oIhzcX5dduetWRBoAhXdthEQM0MQnF+GTXoXL8/luffKgy7PlZRG/WeI/oRQ==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.25.3",
@@ -3177,6 +3179,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/babel-preset/-/babel-preset-0.84.1.tgz",
       "integrity": "sha512-3GpmCKk21f4oe32bKIdmkdn+WydvhhZL+1nsoFBGi30Qrq9vL16giKu31OcnWshYz139x+mVAvCyoyzgn8RXSw==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3225,6 +3228,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.84.1.tgz",
       "integrity": "sha512-n1RIU0QAavgCg1uC5+s53arL7/mpM+16IBhJ3nCFSd/iK5tUmCwxQDcIDC703fuXfpub/ZygeSjVN8bcOWn0gA==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.25.2",
@@ -3247,6 +3251,7 @@
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
       "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hermes-parser": "0.32.0"
@@ -3257,6 +3262,7 @@
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
       "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@react-native/metro-babel-transformer/node_modules/hermes-parser": {
@@ -3264,6 +3270,7 @@
       "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
       "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hermes-estree": "0.32.0"
@@ -3274,6 +3281,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/metro-config/-/metro-config-0.84.1.tgz",
       "integrity": "sha512-KlRawK4aXxRLlR3HYVfZKhfQp7sejQefQ/LttUWUkErhKO0AFt+yznoSLq7xwIrH9K3A3YwImHuFVtUtuDmurA==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@react-native/js-polyfills": "0.84.1",
@@ -3290,6 +3298,7 @@
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.84.1.tgz",
       "integrity": "sha512-UsTe2AbUugsfyI7XIHMQq4E7xeC8a6GrYwuK+NohMMMJMxmyM3JkzIk+GB9e2il6ScEQNMJNaj+q+i5za8itxQ==",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20.19.4"
@@ -12164,37 +12173,34 @@
       "license": "MIT"
     },
     "node_modules/react-native-worklets": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.8.1.tgz",
-      "integrity": "sha512-oWP/lStsAHU6oYCaWDXrda/wOHVdhusQJz1e6x9gPnXdFf4ndNDAOtWCmk2zGrAnlapfyA3rM6PCQq94mPg9cw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.5.1.tgz",
+      "integrity": "sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "@babel/plugin-transform-arrow-functions": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-classes": "^7.28.4",
-        "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
-        "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "@babel/plugin-transform-shorthand-properties": "^7.27.1",
-        "@babel/plugin-transform-template-literals": "^7.27.1",
-        "@babel/plugin-transform-unicode-regex": "^7.27.1",
-        "@babel/preset-typescript": "^7.27.1",
+        "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
+        "@babel/plugin-transform-class-properties": "^7.0.0-0",
+        "@babel/plugin-transform-classes": "^7.0.0-0",
+        "@babel/plugin-transform-nullish-coalescing-operator": "^7.0.0-0",
+        "@babel/plugin-transform-optional-chaining": "^7.0.0-0",
+        "@babel/plugin-transform-shorthand-properties": "^7.0.0-0",
+        "@babel/plugin-transform-template-literals": "^7.0.0-0",
+        "@babel/plugin-transform-unicode-regex": "^7.0.0-0",
+        "@babel/preset-typescript": "^7.16.7",
         "convert-source-map": "^2.0.0",
-        "semver": "^7.7.3"
+        "semver": "7.7.2"
       },
       "peerDependencies": {
-        "@babel/core": "*",
-        "@react-native/metro-config": "*",
+        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "0.81 - 0.85"
+        "react-native": "*"
       }
     },
     "node_modules/react-native-worklets/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -1772,6 +1772,15 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/@expo/config/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@expo/config/node_modules/getenv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
@@ -2187,6 +2196,16 @@
         "xmlbuilder": "^14.0.0"
       }
     },
+    "node_modules/@expo/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@expo/prebuild-config": {
       "version": "54.0.8",
       "resolved": "https://registry.npmjs.org/@expo/prebuild-config/-/prebuild-config-54.0.8.tgz",
@@ -2262,6 +2281,15 @@
       "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.81.5.tgz",
       "integrity": "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g==",
       "license": "MIT"
+    },
+    "node_modules/@expo/prebuild-config/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/@expo/prebuild-config/node_modules/getenv": {
       "version": "2.0.0",
@@ -4655,15 +4683,6 @@
       "dependencies": {
         "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
-      }
-    },
-    "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -7535,6 +7554,15 @@
         "xmlbuilder": "^15.1.1"
       }
     },
+    "node_modules/expo-updates/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/expo-updates/node_modules/arg": {
       "version": "4.1.0",
       "license": "MIT"
@@ -7701,6 +7729,15 @@
         "@xmldom/xmldom": "^0.8.8",
         "base64-js": "^1.2.3",
         "xmlbuilder": "^15.1.1"
+      }
+    },
+    "node_modules/expo/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/expo/node_modules/brace-expansion": {
@@ -11355,6 +11392,15 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/plist/node_modules/xmlbuilder": {

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -10616,9 +10616,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -176,6 +176,6 @@
       "picomatch": ">=3.0.2"
     },
     "yaml": ">=2.8.3",
-    "@xmldom/xmldom": ">=0.9.0"
+    "@xmldom/xmldom": ">=0.8.13 <0.9.0"
   }
 }

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package.json
@@ -76,6 +76,7 @@
     "react-native-svg": "15.12.1",
     "react-native-tab-view": "^3.3.4",
     "react-native-web": "^0.21.0",
+    "react-native-worklets": "0.5.1",
     "rn-bounceable": "^1.2.0",
     "tailwind-merge": "^2.6.0",
     "zod": "^3.22.3",

--- a/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
@@ -7751,9 +7751,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Three dependency fixes in the mobile template. The nanoid bump is the reason the Expo Mobile PUBLISH check runs at all; the other two repair that check, which had been red since 2026-07-10.

## 1. nanoid 3.3.16 to 3.3.18 (both clients)

Clears alert #847, GHSA-2v37-7h3g-55p8 (high): a custom generator loops without end when the caller gives a size of zero.

**Why 3.3.18 and not the 3.3.17 that Dependabot asks for.** 3.3.17 adds the `size <= 0` guard to every entry file except `async/index.native.js`. 3.3.18 adds the guard to that file too. The complete 3.3.17 to 3.3.18 diff is that guard, one README line and the version field. 3.3.18 is also the newest 3.x release and holds the `legacy` dist-tag, so the higher floor costs nothing.

No override is necessary. The four consumers declare `^3.1.23` (`@react-navigation/core`, `@react-navigation/native`, `@react-navigation/routers`) and `^3.3.16` (`postcss`). 3.3.18 is inside both ranges, so a lock file refresh is enough. The export map, the `engines` field and the public exports of 3.3.18 are the same as those of 3.3.16.

In the web client nanoid is a development dependency of postcss, so GitHub dismissed its alert (#848) by scope. The same bump keeps the two clients on one version.

## 2. Narrow the @xmldom/xmldom override to the 0.8 line

The `">=0.9.0"` override, added in #506, made `expo prebuild` fail on the EAS build server:

```
TypeError: [ios.infoPlist]: withIosInfoPlistBaseMod:
DOMParser.parseFromString: the provided mimeType "undefined" is not valid
```

@xmldom/xmldom 0.9.0 makes the second `mimeType` argument of `parseFromString` mandatory. `@expo/plist` gives one argument only, so the parse of the Info.plist throws. Every `@expo/plist` copy in the tree declares `^0.8.8`, and so does the newest release, 0.8.1. Expo has not moved to the 0.9 line, thus the override fought the toolchain.

`">=0.8.13 <0.9.0"` keeps all five advisories closed. Each has a patched release on both lines:

| Advisory | 0.8 line | 0.9 line |
| --- | --- | --- |
| GHSA-2v35-w6hq-6mfw | 0.8.13 | 0.9.10 |
| GHSA-f6ww-3ggp-fr8h | 0.8.13 | 0.9.10 |
| GHSA-x6wf-f3px-wcqx | 0.8.13 | 0.9.10 |
| GHSA-j759-j44w-7fr8 | 0.8.13 | 0.9.10 |
| GHSA-wh4c-j3r5-mjhp | 0.8.12 | 0.9.9 |

0.8.13 was on npm from 2026-04-18, before #506 added the override. The lock file drops the one hoisted 0.9.10 copy and adds six nested 0.8.13 copies, one for each consumer. No other package moves.

The failure was latent from 2026-07-10. An expired iOS provisioning profile masked it, because credentials fail before the remote build starts. The profile was renewed three days ago, and this PR is the first to reach the build phase. The job runs here only because the PR touches the mobile client. It skips on main, which is why main stays green.

## 3. Pin react-native-worklets to 0.5.1

With the override fixed, `expo prebuild` passed and the build reached `pod install`, which then failed:

```
[Reanimated] Invalid version of `react-native-worklets`: "0.8.1".
Expected the version to be in inclusive range "0.5.x, 0.6.x, 0.7.x".
[!] Invalid `RNReanimated.podspec` file.
```

`react-native-reanimated` 4.1.6 declares the peer dependency `react-native-worklets` as `>=0.5.0`, but its `compatibility.json` limits 4.1.x to `0.5.x`, `0.6.x` and `0.7.x`, and the podspec asserts that limit during `pod install`. npm obeyed the loose range, so the package floated to 0.8.1 and the native build refused it.

The package was transitive only, thus nothing held it down. It is now a direct dependency at 0.5.1, the version in the `bundledNativeModules.json` of Expo SDK 54. That is what `npx expo install --fix` writes.

The drift came in with the lock file of #493:

| Commit | worklets | Result |
| --- | --- | --- |
| #473 (SDK 54 upgrade) | 0.7.4 | inside the range |
| #488 (overrides) | absent | — |
| #493 (overrides) | 0.8.1 | outside the range |

## Excluded

Alerts #845 and #846, both image-size (high), stay open. The advisories cover `<= 2.0.2`, and 2.0.2 is the newest release on npm, so no fixed version exists. The consumer is `metro`. Only a change in the Expo toolchain can clear these two alerts.

## Verification

nanoid, in a `node:22` Linux container on a project generated from this branch:

- `npm ci` in `mobile` and in `client`: both exit 0. Each committed lock file agrees with its `package.json`.
- Mobile: `npm run lint:tslint`, `npm run lint:eslint` (`--max-warnings=0`) and `npx expo export --platform web`: all exit 0.
- Web: `npm run tslint`, `npm run eslint` (`--max-warnings=0`), `npm run build` and `vitest run`: all pass.
- The `expo export` and the web build both run nanoid, through metro and through postcss.

@xmldom/xmldom:

- `npm ci` on the new lock file: exit 0. Every `@expo/plist` resolves `@xmldom/xmldom` to 0.8.13.
- `@expo/plist` parse of an Info.plist against the installed 0.8.13: returns the parsed object.
- The same call against 0.9.10 in the same tree: throws the exact `mimeType "undefined"` TypeError from the build log.

react-native-worklets, with the validator that the podspec calls (`scripts/validate-worklets-build.js`), against the installed tree:

- 0.8.1: prints the exact message from the build log, exit 1.
- 0.5.1: exit 0.
- `npm ci` on the new lock file: exit 0.

`pod install` itself needs macOS, so only CI can prove that phase.

> Do not merge this PR without human review.
