### PR TITLE
Fix worktree teardown, Dependabot CI, and Vitest spy leakage

### DIFF
--- a/specs/traefik-multi-project-routing/assertions/project-derived-from-branch.md
+++ b/specs/traefik-multi-project-routing/assertions/project-derived-from-branch.md
@@ -26,11 +26,22 @@ This branch→name rule is the single source of truth for both `_project` (opera
 
 ## Implementation
 
+The rule lives in one recipe, `_project-for`, which takes the branch as an
+argument. `_project` calls it with HEAD. `just worktree` calls it with its
+`<branch>` argument, because HEAD inside a worktree moves whenever someone
+checks out another branch.
+
 ```just
 [private]
 _project:
     #!/usr/bin/env bash
     branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+    just _project-for "$branch"
+
+[private]
+_project-for branch:
+    #!/usr/bin/env bash
+    branch="{{ branch }}"
     if [ "$branch" = "main" ]; then
       echo "{{cookiecutter.project_slug}}-main"
     else
@@ -41,7 +52,8 @@ _project:
 
 ## Success Criteria
 
-- ✅ `_project` recipe exists and is private
+- ✅ `_project` and `_project-for` recipes exist and are private
+- ✅ `_project` derives its answer through `_project-for`, so the rule has one home
 - ✅ `just up` passes `PROJECT=$(just _project)` inline to `docker compose`
 - ✅ `just down` uses the same runtime PROJECT so teardown matches startup
 - ✅ Two worktrees on different branches get different PROJECT values

--- a/specs/traefik-multi-project-routing/assertions/worktree-command.md
+++ b/specs/traefik-multi-project-routing/assertions/worktree-command.md
@@ -49,7 +49,14 @@ branch.
 
 ## `remove` Behavior
 
-1. Runs `just down` in the worktree to stop Docker services
+1. Runs `docker compose down --volumes --rmi local` in the worktree, with
+   `PROJECT` derived from the `<branch>` **argument**, not from the worktree's
+   HEAD. HEAD there moves whenever someone checks out another branch, and a
+   name that no stack ever had makes `down` find nothing to stop and report
+   success while the containers, the volumes, and the network keep running.
+   `--volumes` deletes the database this worktree alone used. `--rmi local`
+   removes only images with a generated name, so the pulled `postgres` and
+   `redis` images stay.
 2. Runs `git worktree remove --force` to delete the directory
 3. Does NOT delete the branch (prints reminder)
 
@@ -60,5 +67,8 @@ branch.
 - ✅ Creates branch if it doesn't exist
 - ✅ Checks out existing branch without error
 - ✅ `just worktree remove feature/x` stops services and removes directory
+- ✅ `remove` names the stack from its `<branch>` argument, so it works after a
+  checkout inside the worktree moved HEAD
+- ✅ `remove` leaves no container, volume, network, or built image behind
 - ✅ Branch remains after remove (user must delete manually)
 - ✅ Two worktrees on different branches run concurrently without port conflicts

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -4,7 +4,19 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     env:
-      SECRET_KEY: {{ "${{ secrets.SECRET_KEY }}" }}
+      # The fallback is what makes this job run on a Dependabot branch.
+      # GitHub withholds repository secrets from a Dependabot-triggered run
+      # and offers a separate Dependabot secret store, which most projects
+      # do not use. Without a fallback, SECRET_KEY arrives empty, settings.py
+      # raises "The SECRET_KEY setting must not be empty" before the first
+      # test, and every test fails on every dependabot/ branch while main
+      # stays green. That red reads as a broken pull request and is not one.
+      #
+      # A test SECRET_KEY signs nothing that outlives the job, so it needs no
+      # secrecy. It must NOT be the production key: a literal here keeps the
+      # two apart, and keeps this working in any fork or repository that has
+      # no secret set.
+      SECRET_KEY: {{ "${{ secrets.SECRET_KEY || 'ci-only-not-a-real-secret' }}" }}
     services:
       postgres:
         image: postgres:latest

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -81,7 +81,8 @@ just worktree add feature/experiment
 just up                                           # in main worktree
 cd ../{{cookiecutter.project_slug}}-experiment && just up   # in experiment worktree
 
-# Tear down and remove a worktree
+# Tear down and remove a worktree. This deletes the stack, its volumes (the
+# worktree database goes with them), and the images the worktree built.
 just worktree remove feature/experiment
 ```
 

--- a/{{cookiecutter.project_slug}}/clients/web/react/vite.config.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/vite.config.ts
@@ -17,6 +17,12 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: './src/setup-tests.ts',
+      // Undo every `vi.spyOn` after each test. Vitest 3 gave a second
+      // `vi.spyOn` on the same method a new spy with an empty call history.
+      // Vitest 4 returns the spy that is already there, history and all, so a
+      // test that asserts `not.toHaveBeenCalled()` reads the calls an earlier
+      // test in the same file made. No test should depend on either behaviour.
+      restoreMocks: true,
     },
     server: {
       host: '0.0.0.0',  // Allow connections from all interfaces

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -19,6 +19,17 @@ default:
 _project:
     #!/usr/bin/env bash
     branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "main")
+    just _project-for "$branch"
+
+# Derive the PROJECT name from a branch name given as an argument. `_project`
+# reads HEAD, which is correct while a command runs inside its own checkout.
+# `worktree remove` cannot use it: it must name the stack that `add` created,
+# and HEAD in a worktree moves whenever someone checks out another branch.
+# The sanitization lives here alone, so both callers keep the same rules.
+[private]
+_project-for branch:
+    #!/usr/bin/env bash
+    branch="{{ "{{ branch }}" }}"
     if [ "$branch" = "main" ]; then
       echo "{{cookiecutter.project_slug}}-main"
     else
@@ -231,7 +242,8 @@ setup-traefik:
 
 # Manage git worktrees with isolated Docker stacks.
 # Usage: just worktree add <branch>    — create worktree and run setup
-#        just worktree remove <branch> — stop Docker stack and remove worktree
+#        just worktree remove <branch> — stop the stack, delete its volumes and
+#                                        built images, and remove the worktree
 [group('docker')]
 worktree action branch:
     #!/usr/bin/env bash
@@ -243,6 +255,10 @@ worktree action branch:
     # e.g. feature/auth_bug -> auth-bug).
     dir_name=$(echo "$BRANCH" | sed 's|^[a-zA-Z][a-zA-Z0-9]*[/_]||' | tr '[:upper:]' '[:lower:]' | tr '/_' '-' | sed 's/[^a-z0-9-]//g')
     worktree_path="../{{cookiecutter.project_slug}}-${dir_name}"
+    # Name the stack from the branch argument, never from the worktree's HEAD.
+    # HEAD in a worktree moves whenever someone checks out another branch, and
+    # `remove` must name the stack that `add` created.
+    project_name=$(just _project-for "$BRANCH")
 
     if [ "{{ "{{ action }}" }}" = "add" ]; then
       echo "Creating worktree for branch '$BRANCH' at $worktree_path..."
@@ -263,7 +279,6 @@ worktree action branch:
 
       # Patch .env so this worktree gets its own PROJECT name and database,
       # preventing container-name and data collisions with other worktrees.
-      project_name="{{cookiecutter.project_slug}}-${dir_name}"
       db_name="{{cookiecutter.project_slug}}_${dir_name//-/_}_db"
       if [ -f "$worktree_path/.env" ]; then
         echo "Patching .env for worktree (PROJECT=$project_name, DB_NAME=$db_name)..."
@@ -323,7 +338,19 @@ worktree action branch:
       fi
 
       echo "Stopping Docker services for '$BRANCH'..."
-      (cd "$worktree_path" && set -a && source .env && set +a && just down)
+      # Pass PROJECT in, and do not call `just down` here. `down` reads the
+      # child's HEAD, and HEAD inside a worktree moves -- a `git checkout`
+      # there is ordinary work. When it moves, `down` gets a name that no
+      # stack ever had, finds nothing to stop, and reports success while the
+      # containers, the volumes, and the network all keep running. The branch
+      # argument cannot drift that way.
+      #
+      # `--volumes` removes the database this worktree alone used, and
+      # `--rmi local` removes the images `add` built. `--rmi local` removes
+      # only images with a generated name, thus the pulled `postgres` and
+      # `redis` images stay for the next worktree, and the build cache stays,
+      # thus the next build is still fast.
+      (cd "$worktree_path" && set -a && source .env && set +a && PROJECT=$project_name docker compose down --volumes --rmi local)
 
       echo "Removing worktree..."
       git worktree remove "$worktree_path" --force


### PR DESCRIPTION
## What This Does

Ports three fixes from a project made with this template: `just worktree remove` now names the Docker stack from its `<branch>` argument and deletes the stack's volumes and built images, the generated pytest workflow gives `SECRET_KEY` a literal fallback, and the generated Vitest config sets `restoreMocks: true`.

`remove` used to run `just down` inside the worktree, and `down` reads the PROJECT name from HEAD. HEAD inside a worktree moves whenever someone checks out another branch there, which is ordinary work, and `down` then gets a name that no stack ever had: it finds nothing to stop and reports success while the containers, the volumes, and the network keep running. The `<branch>` argument cannot drift that way, so the new `_project-for` helper derives the name from it, and `_project` calls the same helper with HEAD so the branch-to-name rule keeps one home. `--volumes --rmi local` then removes what `down` alone left behind; `--rmi local` removes only images with a generated name, so the pulled `postgres` and `redis` images and the build cache stay.

GitHub withholds repository secrets from a Dependabot-triggered run and offers a separate Dependabot secret store instead. A project with no such store gets an empty `SECRET_KEY`, `settings.py` raises "The SECRET_KEY setting must not be empty" before the first test, and every test fails on every `dependabot/` branch while main stays green. A test key signs nothing that outlives the job, so a literal fallback needs no secrecy and keeps the suite working in a fork too. `SECRET_KEY` is the only secret that a Dependabot branch can reach: the Playwright workflow runs on `deployment_status` and `workflow_dispatch`, and no literal can replace `EXPO_TOKEN`.

`restoreMocks: true` is preventive, not a fix: the template has one example test and no `vi.spyOn` at all. Vitest 4, which the template already ships, returns the spy that is already there when a second `vi.spyOn` hits the same method, where Vitest 3 returned a new spy with an empty history, so a test that asserts `not.toHaveBeenCalled()` can read the calls an earlier test in the same file made. This is the default that every new project starts from, and a project made from this template already met the failure.

## Note for reviewers

`just worktree remove` now deletes data: the worktree's Postgres volumes go with the stack, so anything in that worktree's database is gone. Check that this is the behaviour you want from `remove`, because the old command left the volumes on disk.
