### PR TITLE
Let Vitest ignore the Playwright specs

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/web/react/vite.config.ts
+++ b/{{cookiecutter.project_slug}}/clients/web/react/vite.config.ts
@@ -2,6 +2,7 @@
 /// <reference types="vite/client" />
 
 import { defineConfig, loadEnv } from 'vite'
+import { defaultExclude } from 'vitest/config'
 import react from '@vitejs/plugin-react-swc'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
@@ -17,6 +18,16 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: 'jsdom',
       setupFiles: './src/setup-tests.ts',
+      // Keep the Playwright specs away from Vitest. Playwright owns
+      // `tests/e2e/`: its `testDir` points there, `npm run test:e2e` runs
+      // them, and the Playwright workflow runs them on each pull request.
+      // The default `include` of Vitest also matches their `.spec.ts` names,
+      // and Vitest then loads `@playwright/test`, which supplies its own
+      // `test` and `expect`. The file cannot run, thus `npm run test` fails.
+      // This exclusion does not stop a test; it sends each file to the one
+      // runner that can run it. Keep `defaultExclude`, because a given
+      // `exclude` replaces the default list instead of adding to it.
+      exclude: [...defaultExclude, '**/tests/e2e/**'],
       // Undo every `vi.spyOn` after each test. Vitest 3 gave a second
       // `vi.spyOn` on the same method a new spy with an empty call history.
       // Vitest 4 returns the spy that is already there, history and all, so a


### PR DESCRIPTION
## What This Does

Excludes `**/tests/e2e/**` from the Vitest config of the generated React client, so that `npm run test` passes on a new project. It failed before: Vitest collected six files and five of them could not run.

Playwright owns `tests/e2e/`. Its `testDir` points there, the `test:e2e` script runs it, and the Playwright workflow runs it on each pull request. The default `include` of Vitest also matches the `.spec.ts` names below that directory, so each of those files was collected twice: once by the runner that can run it, once by a runner that cannot. Vitest loads `@playwright/test`, which supplies a second `test` and `expect`, and the file then stops with "No test suite found" or "two different versions of @playwright/test". The exclusion removes only the second collection. `defaultExclude` stays in the list, because a given `exclude` replaces the default list instead of adding to it.

## Note for reviewers

Make sure that this exclusion does not hide a test. It does not: Playwright keeps the same files through its own `testDir`, which `exclude` does not touch. In a fresh render, `npx playwright test --list` reports the same 63 tests before and after, and `npm run test` goes from 5 failed and 1 passed to 1 passed.