### PR TITLE
Run the server tests in parallel, and make the local recipe match CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,13 +61,18 @@ jobs:
       - run: |
           config_file="cookiecutter/${{ matrix.fe_type }}_template.yaml"
           uv run cookiecutter . --config-file $config_file --no-input -f
-      - name: Pytest, McCabe, and Coverage
+      # ruff C901 does the complexity check now, thus the name no longer
+      # speaks about McCabe.
+      - name: Pytest and Coverage
         run: |
           cd my_project
           uv sync
           mkdir -p client/dist
           uv run python server/manage.py collectstatic
-          uv run pytest --cov=my_project --cov-config=pyproject.toml -vv server/my_project
+          # The same flags as the generated project's own CI and its justfile
+          # `server-test` recipe. All three run the generated suite, thus all
+          # three must run it the same way.
+          uv run pytest --cov=my_project --cov-config=pyproject.toml -n auto --dist loadscope server/my_project
           uv run coverage report
 
       - name: Check migrations and migration conflicts

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -58,5 +58,16 @@ jobs:
         run: |
           source .venv/bin/activate
           python server/manage.py collectstatic
-          pytest --cov={{ cookiecutter.project_slug }} -vv server/{{ cookiecutter.project_slug }}
-          coverage report --fail-under=20
+          # `-n auto` starts one worker for each core, and pytest-django gives
+          # each worker its own database. `--dist loadscope` keeps all the
+          # tests of a class on one worker, so a class-scoped fixture is made
+          # one time.
+          #
+          # These two flags stay out of `addopts` in pytest.ini on purpose. A
+          # developer who sets a breakpoint wants one process, thus each caller
+          # that wants workers asks for them.
+          #
+          # `fail_under = 60` in pyproject.toml is the coverage gate. pytest-cov
+          # applies it, and this command fails below it, thus no separate
+          # `coverage report` step is necessary.
+          pytest --cov={{ cookiecutter.project_slug }} -n auto --dist loadscope server/{{ cookiecutter.project_slug }}

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -54,6 +54,19 @@ jobs:
           cat .env.example > .env
           cat .env
       - run: mkdir -p client/dist
+      # This step comes before the tests, because the tests cannot find what it
+      # finds. `--no-migrations` in pytest.ini builds the test database from the
+      # models, thus the suite passes whether or not a model change has a
+      # migration file, and nothing reports the gap until a deploy runs
+      # `migrate` against a schema that does not agree with the models.
+      #
+      # `--merge --dry-run` catches the other half: two migration branches that
+      # each apply, but not together.
+      - name: Check migrations and migration conflicts
+        run: |
+          source .venv/bin/activate
+          python server/manage.py makemigrations --check --dry-run
+          python server/manage.py makemigrations --merge --dry-run
       - name: Run tests and checks
         run: |
           source .venv/bin/activate

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -385,11 +385,20 @@ django-makemigrations name="":
 django-migrate:
     cd server && python manage.py migrate
 
+# The gate that `.github/workflows/pytest.yml` applies before it runs the
+# tests, so a developer meets it here first. The tests cannot find what this
+# finds: `--no-migrations` in pytest.ini builds the test database from the
+# models, thus a model change with no migration file keeps the suite green.
+#
 # `uv run`, not a bare `python`, because `server-test` needs this recipe and
 # must not need an activated virtual environment first.
 [group('django')]
 django-check-migrations:
-    cd server && uv run python manage.py makemigrations --check --dry-run
+    #!/usr/bin/env bash
+    set -e
+    cd server
+    uv run python manage.py makemigrations --check --dry-run
+    uv run python manage.py makemigrations --merge --dry-run
 
 [group('django')]
 django-shell:

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -104,14 +104,21 @@ server-run:
     ./server/runserver.sh
     @echo "🚀 Backend ready at http://localhost:8000"
 
+# The same command as `.github/workflows/pytest.yml` runs, thus a green run
+# here means a green run there. It runs from the project root, not from
+# `server/`, because coverage finds `fail_under = 60` in pyproject.toml only
+# from there. See that workflow for what `-n auto --dist loadscope` does.
 [group('server')]
 server-test: django-check-migrations
-    cd server && uv run python -m pytest --mccabe --cov={{ "{{ project }}" }} --cov-config=pyproject.toml -vv {{ "{{ project }}" }} && coverage report
+    uv run pytest --cov={{ "{{ project }}" }} -n auto --dist loadscope server/{{ "{{ project }}" }}
 
-# Run server tests inside Docker (works in both standalone and Traefik mode)
+# Run server tests inside Docker (works in both standalone and Traefik mode).
+# The same command again, because a test run must not depend on where it runs.
+# `/app` is the project root in the container, which the compose bind mount
+# supplies.
 [group('server')]
 server-test-docker:
-    docker compose exec -w /app/server server pytest
+    docker compose exec -w /app server pytest --cov={{ "{{ project }}" }} -n auto --dist loadscope server/{{ "{{ project }}" }}
 
 [group('server')]
 server-format:
@@ -378,9 +385,11 @@ django-makemigrations name="":
 django-migrate:
     cd server && python manage.py migrate
 
+# `uv run`, not a bare `python`, because `server-test` needs this recipe and
+# must not need an activated virtual environment first.
 [group('django')]
 django-check-migrations:
-    cd server && python manage.py makemigrations --check --dry-run
+    cd server && uv run python manage.py makemigrations --check --dry-run
 
 [group('django')]
 django-shell:

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pytest-cov>=6.0.0",
     "pytest-django>=4.8.0",
     "pytest-factoryboy>=2.8.0",
+    "pytest-xdist>=3.6.0",
     "factory-boy==3.2.*",
 ]
 

--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -3,8 +3,8 @@ revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
     "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy') or (python_full_version >= '3.14' and sys_platform != 'win32')",
+    "python_full_version < '3.14' and platform_python_implementation == 'PyPy' and sys_platform == 'win32'",
     "(python_full_version < '3.14' and platform_python_implementation != 'PyPy') or (python_full_version < '3.14' and sys_platform != 'win32')",
 ]
 
@@ -932,6 +932,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1657,6 +1666,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-factoryboy" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -1699,6 +1709,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-django", specifier = ">=4.8.0" },
     { name = "pytest-factoryboy", specifier = ">=2.8.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = "==0.16.0" },
 ]
 
@@ -2356,6 +2367,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/8a/a0f9c58bf176b0d39b630a6e29cccebec9a429dfeb62204bbb9b632fb798/pytest_factoryboy-2.8.1.tar.gz", hash = "sha256:2221d48b31b8b8ccaa739c6a162fb50a43a4de6dff6043f249d2807a3462548d", size = 16906, upload-time = "2025-07-01T04:05:38.901Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/06/2f/4f73a79196b4acb0f902520a805caa22f8ba0adbecdfb028a371404c2537/pytest_factoryboy-2.8.1-py3-none-any.whl", hash = "sha256:91c762cb236bf34b11efdf2e54bafae33114488235621e8b2c4bd9fd77838784", size = 16413, upload-time = "2025-07-01T04:05:37.344Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What This Does

Adds `pytest-xdist` to the generated project and runs the server tests with `-n auto --dist loadscope`, adds a missing-migration check to the generated CI, and repairs the `just server-test` recipe, which could not run at all.

This repository tests itself for a missing migration and gave a generated project no such gate, thus the template now runs the same two commands, as a step before the tests so it fails fast and names itself. The check is necessary although the suite is green, because `--no-migrations` in pytest.ini builds the test database from the models, so the suite passes whether or not a model change has a migration file, and nothing reports the gap until a deploy runs `migrate` against a schema that does not agree with the models. `--merge --dry-run` catches the other half, two migration branches that each apply but not together. The `django-check-migrations` recipe, which `server-test` needs, gets the same second command, so a developer meets the gate that CI applies.

Three commands run the generated test suite: the CI of a generated project, the `server-test` recipe in its justfile, and the bootstrapper CI job that renders the template and tests the result. They had drifted apart, so a green local run said nothing about CI. All three now run the same command. `--dist loadscope` keeps all the tests of a class on one worker, so a class-scoped fixture is made one time, and pytest-django gives each worker its own database. The flags stay off `addopts` in pytest.ini on purpose: a developer who sets a breakpoint wants one process, thus each caller that wants workers asks for them.

`just server-test` failed for three reasons, one after the other, in every generated project. Its `django-check-migrations` dependency called a bare `python` and gave "ModuleNotFoundError: No module named 'django'" without an activated virtual environment. Then `--cov-config=pyproject.toml` after a `cd server` named a file that does not exist, and coverage does not fall back to its defaults, it stops: "coverage.exceptions.ConfigError: Couldn't read 'pyproject.toml' as a config file". Then `--mccabe` gave "error: unrecognized arguments: --mccabe", because ruff C901 replaced pytest-mccabe and the package is in no dependency group. The recipe now runs from the project root, as CI does, so coverage finds pyproject.toml by itself and the `fail_under = 60` gate applies again. `server-test-docker` ran a bare `pytest` with no coverage, and now runs the same command as the rest.

The generated CI also ran `coverage report --fail-under=20` after pytest. That step could not fail, because pytest-cov applies `fail_under = 60` from pyproject.toml and fails the pytest command first, which an experiment with `--cov-fail-under=99` confirms with exit code 1. It is gone.

## Note for reviewers

The migration check is the item to look at first, because it can turn a green project red on the first run. That red is a find, not a regression: it means a model change reached the default branch with no migration file, and only a deploy would have shown it. An experiment on the rendered project shows both halves of the hole: one field added to the User model with no migration file makes the new step exit 1, and leaves all 92 tests green with the coverage gate reached. A project made with this template that takes this up may need to write a migration before its CI is green again.

Be honest about the size of the win from the parallel tests, because the numbers are small. The `Pytest (react)` job of this repository runs the generated suite on a standard 2-core runner, where `-n auto` starts 2 workers. Its test step took 55 s and 56 s on the last two runs on main, and 42 s and 39 s on the two runs of this branch. The step also does `uv sync` and `collectstatic`, so the test part alone improves more than those numbers show. On a 12-core machine with Postgres in a container, three runs of each command on the same 92 tests in 6 files gave 28.3 s with one process, 21.3 s with `-n 2` and 18.3 s with `-n auto`. The setup of a second test database takes back a large part of what a second worker wins on a suite this size, so do not expect this ratio to hold. The value is for a project that grows to hundreds of tests, where that setup cost stays flat and nobody comes back to change CI flags. The risk to know: a test that quietly depends on rows another test left behind fails only under xdist. All 92 tests pass here, and coverage is identical (1840 statements, 411 missed, 78%), but a project with a large suite may need one round of fixes when it takes this up. No migration and no setting in this template creates a Postgres extension, so no worker races another to `CREATE EXTENSION`; the one Postgres-specific field is `ArrayField`, which is native and needs none.
