### PR TITLE
Give the generated CI a timeout and a cancel rule

### DIFF
--- a/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/linting.yml
@@ -1,8 +1,19 @@
 name: Linter
 on: [push]
+
+# Stop the run that is in progress when a second push comes to the same
+# branch. See `pytest.yml` for why. The group holds the name of this
+# workflow, thus it cancels only its own runs.
+concurrency:
+  group: linter-{{ "${{ github.ref }}" }}
+  cancel-in-progress: true
+
 jobs:
   Ruff:
     runs-on: ubuntu-latest
+    # ruff needs seconds. 10 minutes is only a stop for a hang, which without
+    # it runs for the 6-hour GitHub default.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -14,6 +25,9 @@ jobs:
 {%- if cookiecutter.client_app == 'React' %}
   Lint_Web:
     runs-on: ubuntu-latest
+    # More than ruff, because `npm install` gets the whole dependency tree
+    # from the network, and a slow registry is not a hang.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -38,6 +52,9 @@ jobs:
 {%- if cookiecutter.include_mobile == 'y' %}
   Lint_Mobile:
     runs-on: ubuntu-latest
+    # The same as `Lint_Web`, and for the same reason. The mobile dependency
+    # tree is the larger of the two.
+    timeout-minutes: 15
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -1,4 +1,12 @@
 name: Playwright Tests
+# `pytest.yml`, `linting.yml` and `specs.yml` cancel the run that is in
+# progress for the same branch. This workflow does not, because it has no
+# branch to key that on: GitHub documents `github.ref` as empty for a
+# `deployment_status` event that came from a commit SHA. An empty value puts
+# every deployment in one group, thus a deployment of one environment would
+# cancel the tests of another. To add it, key the group on the environment,
+# for example `github.event.deployment_status.environment_url`, and test it
+# with two deployments that overlap.
 on:
   deployment_status:
   workflow_dispatch:

--- a/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/pytest.yml
@@ -1,8 +1,23 @@
 name: Unit Tests
 on: [push]
+
+# A second push to the same branch makes the run that is in progress
+# worthless, because it tests a commit that nobody will merge. Stop it, so
+# that the two runs do not compete for the same runners. The group holds the
+# name of this workflow, thus it cancels only its own runs.
+concurrency:
+  group: unit-tests-{{ "${{ github.ref }}" }}
+  cancel-in-progress: true
+
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    # A job that hangs runs for 6 hours, which is the GitHub default, before
+    # anything stops it. That is billable time for a job that cannot pass, and
+    # it holds a runner. 20 minutes is many times what this job takes, thus it
+    # stays clear of a suite that becomes larger, and it stops a hang the same
+    # day.
+    timeout-minutes: 20
     env:
       # The fallback is what makes this job run on a Dependabot branch.
       # GitHub withholds repository secrets from a Dependabot-triggered run

--- a/{{cookiecutter.project_slug}}/.github/workflows/specs.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/specs.yml
@@ -1,8 +1,20 @@
 name: Specs
 on: [push]
+
+# Stop the run that is in progress when a second push comes to the same
+# branch. See `pytest.yml` for why. The group holds the name of this
+# workflow, thus it cancels only its own runs.
+concurrency:
+  group: specs-{{ "${{ github.ref }}" }}
+  cancel-in-progress: true
+
 jobs:
   Validate_Specs:
     runs-on: ubuntu-latest
+    # This job takes seconds. 5 minutes gives the download of the spekk binary
+    # all the time it needs, and stops a hang that otherwise runs for the
+    # 6-hour GitHub default.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What This Does

Gives every workflow in a generated project that runs on a push a `timeout-minutes` value and a `concurrency` group that cancels the run in progress. This repository tests itself with both guards, and the template had a timeout in `playwright.yml` alone and a concurrency group in two expo workflows alone, so every generated project inherited the gap.

Without `timeout-minutes`, a job that hangs runs to the GitHub default of 6 hours before anything stops it: billable time for a job that cannot pass, and a held runner on a self-hosted fleet. The values come from what each job does, not from one number for all of them. The Python test job gets 20 minutes, because it takes about 90 seconds today and must stay clear of a suite that grows to hundreds of tests. ruff gets 10 minutes, because it needs seconds. Each Node lint job gets 15 minutes, because `npm install` gets a whole dependency tree from the network and a slow registry is not a hang. The spec validation gets 5 minutes, because it takes about 6 seconds plus one binary download.

Without `concurrency`, a second push to the same branch leaves the first run going, the two compete for runners, and the older result is worthless because it tests a commit that nobody will merge. Each workflow keeps its own group name, thus one workflow never cancels the runs of another.

`playwright.yml` gets no group, on purpose. It runs on `deployment_status`, for which GitHub documents `github.ref` as empty when the deployment came from a commit SHA, and an empty value would put every deployment in one group, so a deployment of one environment would cancel the tests of another. A comment in the file names the shape for whoever wants it later, keyed on the environment rather than the ref. The expo workflows also keep the 6-hour default: `eas build` there has no `--no-wait`, so the job waits on a build in a remote queue whose length this repository does not control, and a timeout would stop a legitimate build without stopping the remote work.

## Note for reviewers

The timeouts are testable and the cancel rule is not, and you should treat the two differently. I rendered all three template variants (React, React Native, no client) and confirmed that every workflow still parses as YAML, that the escaping produces a literal `${{ github.ref }}`, and that each job carries the value this description claims. A concurrency rule only shows its behaviour with two runs that overlap on one branch, which no local check can produce, so that half rests on the documented shape and on the two expo workflows that already use it. The thing to check is the group names: `unit-tests-`, `linter-` and `specs-` must stay different from each other, because one shared name would make each workflow cancel the others and leave a branch with no check at all.
