### PR TITLE
Guard this repository's own CI, and key the Playwright group on the URL

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,10 +8,26 @@ on:
         required: false
         default: ''
 
+# The group holds the environment, not the branch. This workflow runs on
+# `deployment_status`, for which GitHub documents `github.ref` as empty when
+# the deployment came from a commit SHA, and an empty value would put every
+# deployment in one group. The URL of the environment names the thing these
+# tests point at: a second deployment to the same URL makes the run that is
+# in progress worthless, because the URL now serves other code, but a
+# deployment to a different URL must not stop it. The two fallbacks keep the
+# group full when a deployment status carries no URL, and for a
+# `workflow_dispatch` run, which has no deployment at all.
+concurrency:
+  group: e2e-${{ github.event.deployment_status.environment_url || github.event.deployment.ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Setup:
     if: github.event.deployment_status.state == 'success' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    # 0.2 minutes in the last three runs. It renders the template and uploads
+    # the result as an artifact.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/expo-build-any-profile.yml
+++ b/.github/workflows/expo-build-any-profile.yml
@@ -33,6 +33,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # No `timeout-minutes` and no `concurrency` group on purpose. `eas build`
+    # here has no `--no-wait`, thus this job waits for a build in a remote
+    # queue whose length this repository does not control. A timeout would
+    # stop the job without a stop of the remote build. A person starts this
+    # workflow by hand, so it does not pile up on a push.
 
     steps:
       - name: 🏗 Setup repo

--- a/.github/workflows/heroku_deploy.yml
+++ b/.github/workflows/heroku_deploy.yml
@@ -1,8 +1,23 @@
 name: Heroku
 on: [push]
+
+# `cancel-in-progress: false`, which queues, where the test workflows cancel.
+# This job changes a Heroku application: it purges a build cache and sets a
+# config variable. A cancel part-way through can leave the application with
+# the cache purged and the variable not set, which is worse than a wait. The
+# queue also keeps two runs from making changes to the same application at
+# the same time.
+concurrency:
+  group: heroku-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   Setup:
     runs-on: ubuntu-latest
+    # 0.6 minutes in the last three runs. The 10 minutes are for the download
+    # of the Heroku CLI and a small number of API calls. This job does not
+    # wait for a Heroku build: Heroku starts that by itself after the push.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: jwalton/gh-find-current-pr@master

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,12 +1,22 @@
 name: Linter
 on: [push]
 
+# Stop the run that is in progress when a second push comes to the same
+# branch. See `pytest.yml` for why. The group name is this workflow's own.
+concurrency:
+  group: linter-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Lock_Files:
     # The Heroku Python buildpack runs `uv sync --locked`, which refuses a lock
     # file that does not agree with its pyproject.toml. Catch that here instead
     # of in a failed deploy.
     runs-on: ubuntu-latest
+    # 0.1 to 0.2 minutes in the last three runs. The 10 minutes cover two
+    # `uv` resolutions and a render of the template, which all need the
+    # network.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -28,6 +38,9 @@ jobs:
 
   Ruff_bootstrapper:
     runs-on: ubuntu-latest
+    # ruff on this repository alone, with no render before it. 0.2 minutes
+    # in the last three runs, thus 5 minutes is only a stop for a hang.
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -55,6 +68,9 @@ jobs:
       matrix:
         fe_type: [react]
     runs-on: ubuntu-latest
+    # More than `Ruff_bootstrapper`, because this job does a `uv sync` and a
+    # full render before it lints. 0.2 to 0.3 minutes in the last three runs.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -85,6 +101,9 @@ jobs:
       matrix:
         fe_type: [react]
     runs-on: ubuntu-latest
+    # `npm install` gets a whole dependency tree from the network, and a slow
+    # registry is not a hang. 0.5 to 0.6 minutes in the last three runs.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -123,6 +142,9 @@ jobs:
         run: npm run eslint
   Lint_Mobile:
     runs-on: ubuntu-latest
+    # The same as `Lint_Web`, and for the same reason. The mobile dependency
+    # tree is the larger of the two: 0.8 to 0.9 minutes in the last three runs.
+    timeout-minutes: 15
     steps:
       - name: 🏗 Setup repo
         uses: actions/checkout@v4

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -1,10 +1,15 @@
 name: Expo Mobile PUBLISH
 on: [deployment_status, workflow_dispatch]
 
+# This workflow gets no `concurrency` group. It publishes, and a publish that
+# stops part-way is worse than two that run one after the other.
 jobs:
   Setup:
     if: github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
+    # This job renders the template and uploads the result. It calls no
+    # remote build service, thus a stop for a hang is safe here.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -35,6 +40,8 @@ jobs:
   configuremobile:
     needs: Setup
     runs-on: ubuntu-latest
+    # A checkout and one `git diff`. Seconds of work.
+    timeout-minutes: 5
     outputs:
       BUILD_MOBILE_APP: ${{ steps.checkdiff.outputs.BUILD_MOBILE_APP }}
     steps:
@@ -57,6 +64,11 @@ jobs:
     if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0
     needs: configuremobile
     runs-on: ubuntu-latest
+    # No `timeout-minutes` on purpose. `eas build` here has no `--no-wait`,
+    # thus this job waits for a build in a remote queue whose length this
+    # repository does not control. A timeout would stop the job, and it would
+    # not stop the remote build, so the work would continue with nothing to
+    # report the result.
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,9 +1,21 @@
 name: Unit Tests
 on: [push]
 
+# A second push to the same branch makes the run that is in progress
+# worthless, because it tests a commit that nobody will merge. Stop it, so
+# that the two runs do not compete for the same runners. Every workflow in
+# this repository keeps a group name of its own, thus one workflow never
+# cancels the runs of another.
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   Pytest_bootstrapper:
     runs-on: ubuntu-latest
+    # 0.2 to 0.3 minutes in the last three runs. The 10 minutes are for a
+    # `uv sync` with no cache, not for the 8 tests.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -26,6 +38,12 @@ jobs:
         run: uv run pytest
   Pytest:
     runs-on: ubuntu-latest
+    # The heaviest job here: it renders the template, syncs the generated
+    # project and runs the generated suite. 1.2 to 1.7 minutes in the last
+    # three runs. 15 minutes, not the 20 that the generated project gets,
+    # because the suite this job runs is the template's own and stays small,
+    # where a real project's suite grows.
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:latest

--- a/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/playwright.yml
@@ -1,12 +1,4 @@
 name: Playwright Tests
-# `pytest.yml`, `linting.yml` and `specs.yml` cancel the run that is in
-# progress for the same branch. This workflow does not, because it has no
-# branch to key that on: GitHub documents `github.ref` as empty for a
-# `deployment_status` event that came from a commit SHA. An empty value puts
-# every deployment in one group, thus a deployment of one environment would
-# cancel the tests of another. To add it, key the group on the environment,
-# for example `github.event.deployment_status.environment_url`, and test it
-# with two deployments that overlap.
 on:
   deployment_status:
   workflow_dispatch:
@@ -15,6 +7,27 @@ on:
         description: 'Base URL to test against'
         required: false
         default: ''
+
+# The group holds the environment, not the branch. `pytest.yml`,
+# `linting.yml` and `specs.yml` key their group on `github.ref`, and this
+# workflow cannot: GitHub documents `github.ref` as empty for a
+# `deployment_status` event that came from a commit SHA, and an empty value
+# would put every deployment in one group.
+#
+# The URL of the environment names the thing these tests point at. A second
+# deployment to the same URL makes the run that is in progress worthless,
+# because the URL now serves other code, but a deployment to a different URL
+# must not stop it. A group of the deployment's ref alone is not sufficient:
+# a staging environment and a production environment that both deploy `main`
+# have one ref and two URLs, and they would stop each other.
+#
+# The two fallbacks keep the group full: `deployment.ref` for a deployment
+# status that carries no URL, and `github.ref` for a `workflow_dispatch` run,
+# which has no deployment at all.
+concurrency:
+  group: playwright-{{ "${{ github.event.deployment_status.environment_url || github.event.deployment.ref || github.ref }}" }}
+  cancel-in-progress: true
+
 jobs:
   test:
     timeout-minutes: 60


### PR DESCRIPTION
## What This Does

Gives this repository's own workflows the two guards that PR #571 gave the generated project, and fills in the one thing #571 left as a comment: the concurrency group for the Playwright workflow. Of the seven workflows here, `e2e.yml` alone set a timeout, on one of its two jobs, and none had a concurrency group, so a hung job ran to the GitHub default of 6 hours and a second push left the first run going.

The values come from the last three runs of each job, not from the numbers the template uses, because these jobs do other work. `Pytest` renders the template and then runs the generated suite, at 1.2 to 1.7 minutes, and gets 15 minutes, which is less than the 20 a generated project gets, because the suite this job runs is the template's own and stays small where a real project's grows. `Pytest_bootstrapper` runs 8 tests in 0.3 minutes and gets 10, which covers a `uv sync` with no cache rather than the tests. `Ruff_bootstrapper` lints this repository alone at 0.2 minutes and gets 5. `Lock_Files` and `Ruff` render the template before they do their work and get 10. `Lint_Web` and `Lint_Mobile` install whole npm trees and get 15, because a slow registry is not a hang. The Heroku job and the two render jobs in `mobile.yml` and `e2e.yml` get 10.

Two jobs keep the 6-hour default on purpose: `publish` in `mobile.yml` and `build` in `expo-build-any-profile.yml`. `eas build` in both has no `--no-wait`, so each waits for a build in a remote queue whose length this repository does not control, and a timeout would stop the local job without stopping the remote build. `heroku_deploy.yml` queues with `cancel-in-progress: false` where the test workflows cancel, because it purges a build cache and sets a config variable on a Heroku application, and a cancel part-way can leave the cache purged and the variable not set. `mobile.yml` publishes, so it gets no group at all. `summary.yml` is off, with `if: false` on its only job.

The generated `playwright.yml` now keys its group on the URL of the environment, with the deployment's ref and `github.ref` as fallbacks. The URL names the thing those tests point at: a second deployment to the same URL makes the run in progress worthless, because the URL now serves other code, while a deployment to a different URL must not stop it. A group on the ref alone is better than nothing, because it is never empty, but it is not sufficient: a staging environment and a production environment that both deploy `main` share one ref and hold two URLs, and they would cancel each other. `e2e.yml` here gets the same expression, because it has the same trigger and the same problem.

## Note for reviewers

Check the group names, because a shared one is the failure that says nothing when it happens: each workflow would cancel the others and leave a branch with no check at all. I checked this by machine rather than by eye. A script parsed all seven workflows here and all eleven in each of the three rendered template variants, 0 parse failures, and counted the group expressions: no name appears twice in any repository. The timeouts are measured and safe to reason about, but no local check can produce two runs that overlap on one branch, so every cancel and queue rule in this change rests on the documented behaviour of `concurrency` and not on an observation. The first real deployment to a preview environment after this merges is what proves the Playwright group.
