### PR TITLE
Run the client unit tests in a generated project

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -123,6 +123,21 @@ def remove_expo_yaml_files():
             remove(file_name)
 
 
+def remove_web_client_yaml_files():
+    """Remove the workflows that need a web client.
+
+    Both run npm in `./client`. Without a web client that directory does not
+    exist, thus every run of them fails and reports nothing about the code.
+    """
+    file_names = [
+        join(".github/workflows", "client-tests.yml"),
+        join(".github/workflows", "playwright.yml"),
+    ]
+    for file_name in file_names:
+        if exists(file_name):
+            remove(file_name)
+
+
 def set_keys_in_envs(django_secret, postgres_secret):
     env_file_path = join(".env.example")
     pull_request_template_path = join(".github", "pull_request_template.md")
@@ -165,6 +180,7 @@ def main():
     if "{{ cookiecutter.client_app }}".lower() == "none":
         rmtree(web_clients_path)
         remove(join("package.json"))
+        remove_web_client_yaml_files()
     elif "{{ cookiecutter.client_app }}".lower() == "react":
         move_web_client_to_root("react")
     if "{{ cookiecutter.include_mobile }}".lower() == "y":

--- a/{{cookiecutter.project_slug}}/.github/workflows/client-tests.yml
+++ b/{{cookiecutter.project_slug}}/.github/workflows/client-tests.yml
@@ -1,0 +1,35 @@
+name: Client Tests
+on: [push]
+
+# Its own workflow, not a job in `linting.yml`. A test is not a lint: this
+# check must say what broke without a look in the log, and a lint failure
+# must not stop the tests, which is what a second step in the same job does.
+# The cost is one more `npm ci`.
+#
+# The post-generation hook removes this file when the project has no web
+# client, because `npm ci` in a directory that does not exist fails every
+# run.
+concurrency:
+  group: client-tests-{{ "${{ github.ref }}" }}
+  cancel-in-progress: true
+
+jobs:
+  Vitest:
+    runs-on: ubuntu-latest
+    # `npm ci` gets a whole dependency tree from the network, which is the
+    # long part of this job, and a slow registry is not a hang. The tests
+    # themselves run in jsdom and touch no database.
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+          cache-dependency-path: ./client/package-lock.json
+      - name: Install dependencies
+        working-directory: ./client
+        run: npm ci
+      - name: Run unit tests
+        working-directory: ./client
+        run: npm run test


### PR DESCRIPTION
## What This Does

Adds a workflow that runs the client unit tests in a generated project, because no workflow ran them. `linting.yml` runs tsc, ESLint and Prettier, `pytest.yml` runs the server suite, `specs.yml` validates the specs, and `playwright.yml` runs the end-to-end tests on a deployment. A generated project shipped a configured vitest, a `test` script, a `setup-tests.ts` and a passing example, and nothing ever ran any of it, so every client test could break while CI stayed green.

It gets its own file rather than a job in `linting.yml`. A job there would repeat the `npm ci` anyway, because each job gets its own runner, and the workflow name would then say "Linter" about a test. A step inside the `Lint_Web` job would share the install, but it makes a test failure look like a lint failure, and steps run one after the other, so a lint failure would stop the tests and hide their result. One more `npm ci` buys a name that is true and a red that says what broke without a look in the log. The job uses `npm ci` rather than `npm install`, because the lock file must decide the versions in CI, and it keys the npm cache on the client lock file the way `playwright.yml` does. It gets 15 minutes for the same reason as the lint jobs: `npm ci` gets a whole dependency tree from the network and a slow registry is not a hang, where the tests run in jsdom and touch no database. The group name is `client-tests-`, which is this workflow's own.

Cookiecutter renders every file, so the guard for a project with no web client goes in the post-generation hook, which is how the expo workflows already work. `playwright.yml` goes out with it, and that part is a fix rather than a guard: it also runs `npm ci` in `./client`, so a project with no web client had a workflow that fails on every deployment and reports nothing about the code. The mobile client has no test script, so this adds no mobile job.

## Note for reviewers

I ran the workflow's commands rather than only reading them. In the rendered project, `npm ci` in `./client` exits 0 and `npm run test` runs vitest 4.1.8 and reports 1 test file and 1 test passed, with exit code 0. That number also confirms the exclusion work from an earlier change: the Playwright specs under `tests/e2e/` are no longer collected by vitest, which is why the count is 1 file and not 6. I rendered all three variants and confirmed the guard by listing the files GitHub would see: react and react-native get `client-tests.yml` and a `client/` directory, and the no-client variant gets neither `client-tests.yml` nor `playwright.yml` and has no `client/` directory. All workflows in all three variants parse as YAML, and no concurrency group name appears twice in any variant. What I cannot show here is the first red: this workflow has never failed, because the template's one example test passes, so the value of the change appears only when someone breaks a client test.
