### PR TITLE
Remove cookiecutter escaping from this repository's own workflows

### DIFF
--- a/.github/workflows/expo-build-any-profile.yml
+++ b/.github/workflows/expo-build-any-profile.yml
@@ -65,7 +65,10 @@ jobs:
         run: |
           cd ./my_project/mobile
           CLEAR_CACHE_FLAG=""
-          if [[ {{ "${{ github.event.inputs.clear_cache }}" }} ]]; then
+          # `clear_cache` is a boolean input, so it arrives as the string
+          # "true" or "false". `[[ false ]]` is TRUE in bash, because the
+          # string is not empty, thus the comparison is what decides it.
+          if [[ "${{ github.event.inputs.clear_cache }}" == "true" ]]; then
             CLEAR_CACHE_FLAG="--clear-cache"
           fi
-          eas build --profile {{ "${{ github.event.inputs.profile }}" }} --platform {{ "${{ github.event.inputs.platform }}" }} --non-interactive $CLEAR_CACHE_FLAG
+          eas build --profile "${{ github.event.inputs.profile }}" --platform "${{ github.event.inputs.platform }}" --non-interactive $CLEAR_CACHE_FLAG

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -49,16 +49,17 @@ jobs:
         with:
           fetch-depth: 5
         name: check diff
+      # No `workflow_dispatch` branch here. `Setup` runs only on a successful
+      # deployment_status, and this job needs `Setup`, so a manual run never
+      # reaches this step.
       - id: checkdiff
         run: |
           git fetch origin main
-          if [ {{ "${{ github.event_name }}" }} == "workflow_dispatch" ]; then
-            echo "This workflow was triggered by a workflow_dispatch event."
-            echo "BUILD_MOBILE_APP=1" >> $GITHUB_OUTPUT
-          else
-            echo $(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l)
-            echo "BUILD_MOBILE_APP=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l)" >> $GITHUB_OUTPUT
-          fi
+          # `tr` strips the padding `wc -l` adds; the `publish` job compares
+          # this output against 0.
+          changed=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
+          echo "Mobile files changed: $changed"
+          echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
 
   publish:
     if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0


### PR DESCRIPTION
## What This Does

Removes the `{{ "..." }}` cookiecutter escaping from three lines in `.github/workflows/`. That escaping belongs in the template, whose files cookiecutter renders. These files are never rendered, so GitHub substitutes the inner expression and leaves the literal braces in the shell command.

The two files fail differently, and I confirmed both by running the constructs rather than by reading them. `mobile.yml` used single brackets, where bash reports "too many arguments", takes the else branch, and carries on. Its outcome was right by luck: `Setup` runs only on a successful `deployment_status` and this job needs `Setup`, so the `workflow_dispatch` branch it guarded could never run. That branch is deleted rather than repaired. `expo-build-any-profile.yml` used double brackets, which bash parses as a keyword, so the braces are a syntax error: the script exits 2 and no later line runs, and `eas build` never ran at all. That workflow is `workflow_dispatch`, so it is reachable, and it could not work.

The escaping was not the only fault in the expo file. `clear_cache` is a boolean input, so it arrives as the string `true` or `false`, and `[[ false ]]` is true in bash because the string is not empty. Correcting the escaping alone would have added `--clear-cache` to every build, so the condition now compares against `"true"`.

## Note for reviewers

`wc -l` pads its output, and the `publish` job gates on `BUILD_MOBILE_APP != 0`, so `tr` now strips the padding. That value has always been padded and the gate has always worked, so this is a hardening rather than a fix; check that you agree it is worth the line.

Verified by execution with a stubbed `eas`: `clear_cache=true` adds the flag, `false` does not, and the profile and platform arrive as single arguments. The diff count returns 0 and 1 correctly against a scratch repository with the same path depth. What cannot be checked here is a real `eas build`, so the expo workflow is proven only up to the point where it invokes the CLI.