### PR TITLE
fix(security): update sqlparse to 0.6.0 to close 4 CVEs

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -98,4 +98,5 @@ constraint-dependencies = [
     "lxml>=6.1.0",
     "idna>=3.15",
     "msgpack>=1.2.1",
+    "sqlparse>=0.6.0",
 ]

--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -21,6 +21,7 @@ constraints = [
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "pynacl", specifier = ">=1.6.2" },
     { name = "pyopenssl", specifier = ">=26.0.0" },
+    { name = "sqlparse", specifier = ">=0.6.0" },
     { name = "twisted", specifier = ">=26.4.0" },
     { name = "ujson", specifier = ">=5.13.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
@@ -2796,8 +2797,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "platform_python_implementation != 'PyPy' or sys_platform != 'win32'" },
+    { name = "jeepney", marker = "platform_python_implementation != 'PyPy' or sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -2837,11 +2838,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR raises the sqlparse floor to 0.6.0. Sqlparse is a transitive dependency. Django pulls it in. No file in this repository names sqlparse directly. The fix adds one line to the uv constraint-dependencies list in `{{cookiecutter.project_slug}}/pyproject.toml`, then updates `{{cookiecutter.project_slug}}/uv.lock` to match.

## Closed alerts

| Alert | GHSA ID | Severity |
|---|---|---|
| #856 | GHSA-prg7-hcfm-mfcr | High |
| #855 | GHSA-pwgv-4x5q-6m9f | High |
| #850 | GHSA-f2ff-p2ww-7p4p | High |
| #849 | GHSA-3496-9g83-7v6x | Medium |

Version 0.6.0 fixes all four issues in one release.

## Alerts this PR does not close

Alerts #851, #852, #853, and #854 name the same CVEs. They point to `my_project/uv.lock`. That file does not exist on the main branch. PR #501 removed it on 2026-07-13. These four alerts appeared on 2026-08-17, over a month after the file's removal. My view: these are stale entries in the dependency graph, not real risk. A human may want to dismiss them by hand in the Dependabot alert list.

Alerts #845 and #846 name a different package, image-size, in the mobile npm lock file. This PR does not touch that package. It needs its own PR.

## Verification

I ran a generated project through these checks, in a Linux container:

- `uv lock --check` — the lock file agrees with the manifest.
- `uv run python -c "import sqlparse; print(sqlparse.__version__)"` — prints 0.6.0.
- `uv run ruff check server` — all checks pass.
- `uv run pytest --cov=my_project --cov-config=pyproject.toml -n auto --dist loadscope server/my_project` — 92 tests pass, coverage 77.61 percent, above the 60 percent floor.
- `uv run python server/manage.py makemigrations --check --dry-run` and `--merge --dry-run` — no changes, no conflicts.

No source file in this repository calls sqlparse directly. No call site needed a check for the new version's API shape.

Do not merge this PR. A human must review and merge it.
