### PR TITLE
Validate specs in CI

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,36 @@
+name: Specs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Stay green in a branch that has no specs yet, without downloading a
+      # binary it will not use.
+      - name: Look for specs
+        id: check
+        run: |
+          if [ -d specs ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Pinned on purpose. Without a pin the install takes the latest
+      # release, and a stricter validator in a future version would fail
+      # this repository with no change on its side. Raise it deliberately.
+      - name: Install spekk
+        if: steps.check.outputs.found == 'true'
+        env:
+          SPEKK_VERSION: v1.26.0
+        run: curl -fsSL https://raw.githubusercontent.com/spekk-ai/spekk-cli/main/install.sh | sh
+
+      - name: Validate specs
+        if: steps.check.outputs.found == 'true'
+        run: ~/.local/bin/spekk validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,10 @@ repos:
         always_run: true
         verbose: true
         stages: [pre-commit]
+
+  # Spec validation. The hook only runs when a staged file is under
+  # specs/, so a commit that touches nothing there never invokes it.
+  - repo: https://github.com/spekk-ai/spekk-cli
+    rev: v1.26.0
+    hooks:
+      - id: spekk-validate


### PR DESCRIPTION
## What This Does

Adds `.github/workflows/specs.yml`, which runs `spekk validate` on pull requests and pushes to `main`. This repository carries specs, and until now nothing checked them.

The failure this guards against is not local to one file. One malformed frontmatter field fails the parse of the **whole tree**, so a single bad line on `main` stops every command that rebuilds the index — `spekk next`, `spekk query`, `spekk observer announce` — for every branch and every user, until a person finds it. Scheduled agents keep running and keep reporting nothing, which is why it can sit unnoticed.

`SPEKK_VERSION` is pinned deliberately rather than floating, so a stricter validator in a future release cannot turn this repository red with no change on its side. Raising it is a small deliberate step at release time.

## Note for reviewers

Verified before opening this, not after: `spekk validate` at `v1.26.0` exits 0 against this tree — 1 spec, 21 assertions OK. So it should be green on arrival rather than handing you pre-existing problems to fix.

The job skips itself when there is no `specs/` directory, so it stays green on a branch that predates them and downloads nothing there.