### PR TITLE
Bump @faker-js/faker to 10 in the web client

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package-lock.json
@@ -31,7 +31,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.35.0",
-        "@faker-js/faker": "^9.9.0",
+        "@faker-js/faker": "^10.5.0",
         "@playwright/test": "^1.50.0",
         "@tanstack/eslint-plugin-query": "^5.86.0",
         "@testing-library/jest-dom": "^6.2.0",
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@faker-js/faker": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
-      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.6.0.tgz",
+      "integrity": "sha512-3RQHgEtvL1Frl/d1cSreo7qhJ3Gk1OdNUai/CtZ8G+wYeRQnJih3s9xJ9/kgYekPQRdwgh0HXRPqMlzWGwivIQ==",
       "dev": true,
       "funding": [
         {
@@ -846,8 +846,8 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=9.0.0"
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@floating-ui/core": {

--- a/{{cookiecutter.project_slug}}/clients/web/react/package.json
+++ b/{{cookiecutter.project_slug}}/clients/web/react/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.35.0",
-    "@faker-js/faker": "^9.9.0",
+    "@faker-js/faker": "^10.5.0",
     "@playwright/test": "^1.50.0",
     "@tanstack/eslint-plugin-query": "^5.86.0",
     "@testing-library/jest-dom": "^6.2.0",


### PR DESCRIPTION
## What This Does

Clears the last of the thirteen alerts that opened after #586: a high-severity advisory on `@faker-js/faker` 9.9.0. The advisory has no fix below 10.5.0, so the pin has to move a major version rather than a patch.

faker 10 is ESM-only and requires Node `^22.13.0`. Every workflow that touches the web client already runs Node 22, so nothing in CI has to change. This is a `devDependencies` entry, so it never reaches a built application.

The bump sits in its own pull request, apart from the four lock-file-only updates in #593, so it can be reviewed and reverted on its own.

## Note for reviewers

Only `tests/e2e/specs/utils/fake-data.ts` imports faker, and it calls six methods: `string.uuid`, `internet.email`, `person.firstName`, `person.lastName`, `date.past` and `date.recent`. All six keep the same signature in 10, and I ran each one against 10.6.0 to confirm. The Playwright job is the check that proves it end to end, since that file only runs there.