### PR TITLE
Move the server image from bullseye to bookworm

### DIFF
--- a/{{cookiecutter.project_slug}}/compose/server/Dockerfile
+++ b/{{cookiecutter.project_slug}}/compose/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bookworm
 
 # These environment values help with watching for file changes
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
## What This Does
Moves the template's server Dockerfile from `python:3.12-slim-bullseye` to `python:3.12-slim-bookworm`.

Debian 11 left long-term support on 2026-08-31, and its security suite is no longer on `deb.debian.org`. The Dockerfile's second layer runs `apt-get update && apt-get install ...`, and on bullseye that step now fails with 404s from `debian-security`, so a project generated from this template cannot build its server image on first run. The same change just landed in `thinknimble/foreverfit` (#552), where the production deploy build proved that `build-essential`, `gcc`, `libpq-dev`, `libjpeg-dev`, `zlib1g-dev`, and `python3-pip` install on bookworm under the same names.

## Note for reviewers
The template's own checks are the proof: they render and lint the generated project. A generated project's first `docker compose build server` is the real test, and it needs a machine with no cached bullseye layer.