### PR TITLE
fix(security): constrain httpx2 to >=2.12.0 to close 6 CVEs

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -99,4 +99,5 @@ constraint-dependencies = [
     "idna>=3.15",
     "msgpack>=1.2.1",
     "sqlparse>=0.6.0",
+    "httpx2>=2.12.0",
 ]

--- a/{{cookiecutter.project_slug}}/uv.lock
+++ b/{{cookiecutter.project_slug}}/uv.lock
@@ -14,6 +14,7 @@ constraints = [
     { name = "cbor2", specifier = ">=5.9.0" },
     { name = "cryptography", specifier = ">=50.0.0" },
     { name = "filelock", specifier = ">=3.20.3" },
+    { name = "httpx2", specifier = ">=2.12.0" },
     { name = "idna", specifier = ">=3.15" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "msgpack", specifier = ">=1.2.1" },
@@ -1120,15 +1121,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.9.1"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -1157,18 +1158,28 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.9.1"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
     { name = "idna" },
-    { name = "truststore" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This pull request adds a `uv` constraint that lifts **httpx2** to `>=2.12.0`. `httpx2` is a transitive package: `pydantic-ai` → `genai-prices` → `httpx2` → `httpcore2`. No manifest names it, so a constraint in `[tool.uv] constraint-dependencies` is the correct control, and it matches the way earlier CVE floors are set in this file.

`httpx2 2.12.0` pins `httpcore2==2.12.0`, so the single floor moves both packages. `genai-prices` only asks for `httpx2>=2.0`, so the floor stays inside major 2 and does not conflict.

## Alerts closed (6)

| GHSA | Package | Severity | Patched | Alert |
|---|---|---|---|---|
| GHSA-8xx6-hgc6-gc2m | httpx2 | high | 2.12.0 | #897 |
| GHSA-7mj9-2mp8-4m2p | httpx2 | high | 2.10.0 | #886 |
| GHSA-7mj9-2mp8-4m2p | httpcore2 | high | 2.10.0 | #894 |
| GHSA-pf96-p4fj-6566 | httpx2 | moderate | 2.11.0 | #896 |
| GHSA-h4x7-gw46-3wm6 | httpx2 | moderate | 2.11.0 | #895 |
| GHSA-f2fp-rgf2-35cp | httpx2 | moderate | 2.10.0 | #887 |

## What changed

- `pyproject.toml`: add `"httpx2>=2.12.0"` to `constraint-dependencies`.
- `uv.lock`: `httpx2` 2.9.1 → 2.12.0, `httpcore2` 2.9.1 → 2.12.0. The lock also adds `httpx2-jsfetch`, a new transitive dependency that is marker-gated to `sys_platform == 'emscripten'`, so it never installs on a server or on Linux.

The lock change is limited to these packages; no other package moves.

## How I verified

I generated a React project from the modified template, then ran these steps in Linux containers:

1. `uv lock` re-resolved 180 packages and reported `Updated httpcore2 2.9.1 -> 2.12.0` and `Updated httpx2 2.9.1 -> 2.12.0`.
2. `uv sync --frozen` installed the full tree on Linux. `python -c "import httpx2, httpcore2"` reported `2.12.0` and `2.12.0`. The consumer chain imported too: `genai_prices` and `pydantic_ai`.
3. The generated server test suite ran against a PostgreSQL service, the same way CI runs it:
   `uv run pytest -n auto --dist loadscope server/<project>` → **92 passed** in 111.80s. This suite includes the chat tests, which import `pydantic_ai` — the code path that uses `httpx2`.

## Alerts not closed

None in this cluster. All six `httpx2`/`httpcore2` alerts are closed by this floor.
