### PR TITLE
Bump js-yaml in the mobile client to close GHSA-2883-xcg3-v3hh

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/package-lock.json
@@ -2440,9 +2440,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
-      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -9282,9 +9282,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## What This Does

Moves the two locked `js-yaml` trees in the React Native client to their patched releases, closing alerts #889 and #888 (high, GHSA-2883-xcg3-v3hh: `maxTotalMergeKeys` does not limit CPU use for empty merge sources).

| Path | Before | After |
|---|---|---|
| `node_modules/js-yaml` | 4.3.1 | 4.3.2 |
| `node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml` | 3.15.1 | 3.15.2 |

The change is in `package-lock.json` alone. The dependers ask for `js-yaml@^4.1.0` (eslint, `@eslint/eslintrc`, `@expo/xcpretty`) and `js-yaml@^3.13.1` (`@istanbuljs/load-nyc-config`), and both patched versions sit inside those ranges, so an `overrides` entry in `package.json` would add nothing. This is the same shape as the web-client fix in #596.

I edited the two lock entries by hand rather than regenerating the file. A full `npm install --package-lock-only` on npm 11 rewrote 371 lines and dropped `@react-native/metro-config` and `@react-native/metro-babel-transformer`, which are reached through an optional peer dependency of `@react-native/community-cli-plugin`. That collateral does not belong in a security patch. Both releases are patch-level with identical dependency metadata, so version, `resolved` and `integrity` are the only fields that move.

To verify, I installed the client from this lock and confirmed npm keeps both patched versions in place, that `require('js-yaml')` parses, and that eslint 8.57.1 still starts.

## Note for reviewers

Three mobile alerts stay open on purpose, and neither is fixed here:

- **#857 `decode-uri-component`** (moderate). The patch is 0.5.0, which is ESM-only (`"type": "module"`, `export default`). Its only depender, `query-string@7.1.3`, is CommonJS and calls `require('decode-uri-component')`. Forcing 0.5.0 would break that call, so this one needs a `query-string` upgrade through `@react-navigation/core`, not an override.
- **#846 and #845 `image-size`** (high). No patched release exists. The advisories cover `<= 2.0.2`, and 2.0.2 is still the latest version on npm. Nothing to bump to yet.