### PR TITLE
Stop the Expo publish on a non-PR deployment

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -44,6 +44,7 @@ jobs:
     timeout-minutes: 5
     outputs:
       BUILD_MOBILE_APP: ${{ steps.checkdiff.outputs.BUILD_MOBILE_APP }}
+      PR_NUMBER: ${{ steps.prnumber.outputs.PR_NUMBER }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -60,9 +61,21 @@ jobs:
           changed=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
           echo "Mobile files changed: $changed"
           echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
+      # The build profile this workflow writes is named `review_<PR number>`,
+      # and the number comes from the review app's URL. A staging or
+      # production deployment has no `pr-<number>` in its URL, which leaves
+      # the name as `review_` and makes `eas build` fail. The `publish` job
+      # tests this output so that such a deployment stops here instead.
+      - id: prnumber
+        run: |
+          pr_number=$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+' || true)
+          echo "PR number: ${pr_number:-<none>}"
+          echo "PR_NUMBER=$pr_number" >> $GITHUB_OUTPUT
+        env:
+          ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
 
   publish:
-    if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0
+    if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0 && needs.configuremobile.outputs.PR_NUMBER != ''
     needs: configuremobile
     runs-on: ubuntu-latest
     # No `timeout-minutes` on purpose. `eas build` here has no `--no-wait`,


### PR DESCRIPTION
## What This Does

Makes the `publish` job stop when the deployment that triggered it is not a pull request.

The job builds a review app under a profile it writes as `review_<PR number>`, and it reads that number out of the review app's URL with `grep -oP '(?<=pr-)\d+'`. A staging deployment has no `pr-<number>` in its URL, so the number came out empty, the profile became `review_`, the channel ended in a bare hyphen, and `eas build` errored 44 seconds in with "Unknown error. See logs of the Build complete hook build phase".

That is what failed on main today. The deployment was for `tn-spa-bootstrapper-staging`, not for a pull request. The EAS build list makes the pattern plain: every build that finished carries a real number in its profile (`review_593`, `review_588`, `review_567`), and the one that errored carries `review_`.

The fix reads the number once in `configuremobile`, publishes it as a job output, and lets `publish` test it alongside the existing mobile-diff test. A deployment with no PR number now stops at that job instead of starting a build that cannot succeed.

## Note for reviewers

This changes when the job runs, not what it does, so the only real risk is the guard being too strict and skipping a build that should have happened. I checked the extraction against the three URL shapes this workflow sees: a review app (`...-pr-599.herokuapp.com`) yields `599` and publishes, staging yields empty and skips, and an empty URL yields empty and skips.

Worth knowing but not fixed here: `configuremobile` decides whether mobile files changed with `git diff --name-only origin/main` from the deployment's commit. When that commit is already behind main, the diff reports the *newer* commits' mobile changes, so the job can build the wrong tree. That race is why `publish` ran at all on a staging deployment whose own commit touched no mobile file. The guard in this PR stops the bad build either way, so the race now costs nothing worse than a skipped job, but it is still the wrong question to ask and it deserves its own change.