### PR TITLE
Build the staging profile on a staging deployment

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -61,21 +61,21 @@ jobs:
           changed=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
           echo "Mobile files changed: $changed"
           echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
-      # The build profile this workflow writes is named `review_<PR number>`,
-      # and the number comes from the review app's URL. A staging or
-      # production deployment has no `pr-<number>` in its URL, which leaves
-      # the name as `review_` and makes `eas build` fail. The `publish` job
-      # tests this output so that such a deployment stops here instead.
+      # A review app's URL carries `pr-<number>`; a staging deployment's does
+      # not. The `publish` job builds `review_<number>` for the first and the
+      # `staging` profile for the second. Before this output existed, a
+      # staging deployment produced the profile name `review_`, which does
+      # not exist, and `eas build` errored.
       - id: prnumber
         run: |
           pr_number=$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+' || true)
-          echo "PR number: ${pr_number:-<none>}"
+          echo "PR number: ${pr_number:-<none, this is a staging deployment>}"
           echo "PR_NUMBER=$pr_number" >> $GITHUB_OUTPUT
         env:
           ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
 
   publish:
-    if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0 && needs.configuremobile.outputs.PR_NUMBER != ''
+    if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0
     needs: configuremobile
     runs-on: ubuntu-latest
     # No `timeout-minutes` on purpose. `eas build` here has no `--no-wait`,
@@ -135,10 +135,21 @@ jobs:
       - name: Set Variables
         id: set-vars
         run: |
+          pr_number=$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+' || true)
+          # A review app builds its own `review_<number>` profile. A staging
+          # deployment builds `staging`, which eas.json already defines.
+          if [ -n "$pr_number" ]; then
+            build_profile="review_$pr_number"
+            channel_suffix="$pr_number"
+          else
+            build_profile="staging"
+            channel_suffix="staging"
+          fi
           echo "backend_url=${ENVIRONMENT_URL:-https://default-backend-url.com}" >> $GITHUB_ENV
-          echo "PR_NUMBER=$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+')" >> $GITHUB_ENV
+          echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
+          echo "BUILD_PROFILE=$build_profile" >> $GITHUB_ENV
           echo "REPO_NAME=$(echo "$REPO" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]//g')" >> $GITHUB_ENV
-          echo "EXPO_CHANNEL=$(echo "$REPO-$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+')" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]//g')" >> $GITHUB_ENV
+          echo "EXPO_CHANNEL=$(echo "$REPO-$channel_suffix" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9._-]//g')" >> $GITHUB_ENV
         env:
           ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
           REPO: ${{ github.repository }}
@@ -146,8 +157,8 @@ jobs:
       - name: Update EAS Config
         working-directory: ./my_project/mobile
         run: |
-          jq --arg pr_number "$PR_NUMBER" --arg expo_channel "$EXPO_CHANNEL" --arg backend_url "$BACKEND_URL" '
-            .build["review_" + $pr_number] = {
+          jq --arg build_profile "$BUILD_PROFILE" --arg expo_channel "$EXPO_CHANNEL" --arg backend_url "$BACKEND_URL" '
+            .build[$build_profile] = ((.build[$build_profile] // {}) * {
               "developmentClient": false,
               "distribution": "internal",
               "channel": $expo_channel,
@@ -157,8 +168,8 @@ jobs:
             "SENTRY_DSN": "https://d8669d3eb6e3649cfd05069423434b86@o4508768170409984.ingest.us.sentry.io/4508768174145536",
             "SENTRY_PROJECT_NAME": "tn-spa-prod"
               }
-          } |
-          .build["review_" + $pr_number + "_dc"] = {
+          }) |
+          .build[$build_profile + "_dc"] = ((.build[$build_profile + "_dc"] // {}) * {
             "developmentClient": true,
             "distribution": "internal",
             "channel": ($expo_channel + "_dc"),
@@ -168,7 +179,7 @@ jobs:
           "SENTRY_DSN": "https://d8669d3eb6e3649cfd05069423434b86@o4508768170409984.ingest.us.sentry.io/4508768174145536",
           "SENTRY_PROJECT_NAME": "tn-spa-prod"
             }
-          }
+          })
           ' eas.json > tmp.$$.json && mv tmp.$$.json eas.json
         env:
           BACKEND_URL: ${{ github.event.deployment_status.environment_url || 'https://default-backend-url.com' }}
@@ -178,12 +189,12 @@ jobs:
         run: cat eas.json
 
       # note: you will need to register your device first using eas device:create & eas credentials to test this
-      - name: Build review app (BUILD)
+      - name: Build the app (BUILD)
         working-directory: ./my_project/mobile
         run: |
-          eas build --platform ios --profile "review_${{ env.PR_NUMBER }}" --non-interactive
+          eas build --platform ios --profile "$BUILD_PROFILE" --non-interactive
 
-      - name: Build review app (Simulator BUILD)
+      - name: Build the app (development client BUILD)
         working-directory: ./my_project/mobile
         run: |
-          eas build --platform ios --profile "review_${{ env.PR_NUMBER }}_dc" --non-interactive
+          eas build --platform ios --profile "${BUILD_PROFILE}_dc" --non-interactive


### PR DESCRIPTION
## What This Does

Makes the publish job pick its build profile from the deployment instead of assuming every deployment is a pull request.

#600 stopped the job when the deployment carried no PR number. That removed the failing build, but it was the wrong trade twice over: the `eas update` step in that job had **succeeded**, and eas.json has carried a `staging` profile all along that nothing ever built. This replaces that skip with the build the deployment actually deserves.

| Deployment | Profile | Channel | Backend |
|---|---|---|---|
| `...-pr-599.herokuapp.com` | `review_599` | `<repo>-599` | the review app |
| `...-staging.herokuapp.com` | `staging` | `<repo>-staging` | the staging app |

The pull request path is unchanged, down to the channel string. Only the staging path is new.

The jq step now merges into the profile rather than replacing it. A `review_<number>` profile does not exist beforehand, so that path behaves exactly as it did. The `staging` profile does exist, and a plain replace would have dropped its `BUILD_ENV`, which `app.config.js` reads into `buildEnv` at line 55.

I ran both paths against a freshly rendered `eas.json`. A `pr-599` URL produces profile `review_599`, channel `thinknimbletn-spa-bootstrapper-599` and the review backend, matching what the workflow produced before. A staging URL produces profile `staging`, channel `thinknimbletn-spa-bootstrapper-staging`, the staging backend, and `BUILD_ENV=staging` intact.

## Note for reviewers

**This spends EAS build minutes on main, which nothing did before.** A merge that touches the mobile client now starts two iOS builds, `staging` and `staging_dc`. That is the intended change, but it is worth knowing before it lands, and dropping the `_dc` step for staging would halve it if you would rather.

The staging build is not proven. Its one recorded attempt, on 2026-08-11, errored in the fastlane step, and no staging build has run since. So expect the first merge that touches mobile to tell us something new, and treat a failure there as a fresh problem rather than a regression from this change.

Two things I deliberately left alone. The jq step writes no `BUILD_ENV` for review profiles, so review builds have had `buildEnv` undefined all along; fixing that changes review behavior and belongs in its own PR. And `configuremobile` still decides using `git diff --name-only origin/main` from the deployment's commit, so a commit that is already behind main reports the *newer* commits' mobile changes. That race is what made this job run on a staging deployment in the first place, and it is still there.