### PR TITLE
Let EAS archive the rendered project again

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -120,6 +120,24 @@ jobs:
         working-directory: ./my_project/mobile
         run: npm install
 
+      # EAS archives the project through git and honors .gitignore, which
+      # ignores my_project/ so that a local render stays out of `git status`.
+      # But the rendered app is exactly what EAS has to upload, so the archive
+      # arrived without it and every build died with "package.json does not
+      # exist in .../my_project/mobile".
+      #
+      # EAS reads .easignore at the git root in place of .gitignore, so derive
+      # one that drops only that line. Deriving it, rather than checking a
+      # second ignore file into the repository, keeps every other rule in
+      # force - the .env rules above all - with nothing to drift.
+      - name: Let EAS archive the rendered project
+        run: |
+          grep -vE '^/?my_project/?$' .gitignore > .easignore
+          if grep -qE '^/?my_project/?$' .easignore; then
+            echo "my_project is still ignored; EAS would upload an archive without it" >&2
+            exit 1
+          fi
+
       - name: 🚀 Publish preview
         working-directory: ./my_project/mobile
         run: |


### PR DESCRIPTION
## What This Does

Fixes every iOS build, which has failed since 2 September.

`432ee474` added `my_project/` to `.gitignore` that day, to keep a local render out of `git status`. EAS Build archives the project through git and honors `.gitignore`, so from that commit on the rendered app stopped reaching the build server, and the build died with `package.json does not exist in /Users/expo/workingdir/build/my_project/mobile`.

Three independent things agree:

| Evidence | |
|---|---|
| Timing | `review_593`, the last build that finished, ran 21 minutes before `432ee474` and does not contain it. Every failing build does. |
| Upload size | 4.5 MB on the successful builds, 3.1 MB on every one since. |
| Error text | It names the exact missing path. |

**The build profile had nothing to do with it.** I want to be plain about that, because #600 and #601 both said otherwise. `review_593` finished; `review_` and `review_602` failed identically. The empty `review_` profile was a real latent bug and #601 fixes it properly, but it was never why the builds failed.

EAS reads `.easignore` at the git root in place of `.gitignore`, so the job derives one that drops only the `my_project` line. Deriving it beats checking a second ignore file into the repo: every other rule stays in force automatically, including the `.env` and `.env.local` rules, and there is nothing to drift out of sync. If a future edit renames that line, the step fails loudly rather than uploading an archive without the app.

## Note for reviewers

**This PR cannot test itself, and that is worth knowing before you approve it.** It touches only the workflow, so `configuremobile` reports zero mobile files changed and the publish job skips. The next pull request that touches `clients/mobile/react-native/` will exercise it, through the review path.

**A second problem this uncovered, not fixed here: the staging build can essentially never run.** `configuremobile` decides with `git diff --name-only origin/main` taken from the deployment's commit. On a pull request branch that is the right question. On main the deployment commit *is* `origin/main`, so the diff is always empty. The staging deployment for #602 proved it: that merge changed the mobile lockfile, and the job still logged `Mobile files changed: 0`. So the staging support added in #601 is unreachable in practice, and today's one staging run only happened because a deployment for an older commit raced a newer main. Making staging builds real means diffing against the previous commit on main, which also means starting to spend EAS build minutes there. That is a decision rather than a bug fix, so it is not in this PR.