### PR TITLE
Format validators.ts with prettier

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/services/validators.ts
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/services/validators.ts
@@ -26,7 +26,7 @@ export const NAME_PATTERN = /^[a-zA-ZÀ-ÖØ-öø-ÿ\s'-]+$/
 
 export const nameValidator = new PatternValidator({
   pattern: NAME_PATTERN,
-  message: "Name may only contain letters, hyphens, apostrophes, and spaces",
+  message: 'Name may only contain letters, hyphens, apostrophes, and spaces',
   code: 'invalidName',
   isRequired: true,
 })


### PR DESCRIPTION
## What This Does

`npm run format:check` reports three files in the mobile client. This fixes the one prettier can actually parse: a double-quoted string where the project's config asks for single quotes.

The other two, `date-picker-modal.tsx` and `routes.tsx`, hold Jinja `{% raw %}` blocks, so prettier errors on them rather than warning - it cannot parse the template form at all. Formatting those would mean rendering the template, formatting the output, and putting the raw markers back by hand, which is not a trade worth making for quoting style. No CI job runs `format:check`, so neither file is blocking anything today.

## Note for reviewers

**The real reason this PR exists now is to test #603, and it is the first chance to do so.** It touches `clients/mobile/react-native/`, so the mobile-diff gate opens, the publish job runs on this pull request's review app, and the build goes through the new `.easignore` step. Every iOS build since 2 September has failed because the rendered project was excluded from the EAS archive; if #603 is right, this build gets past `package.json does not exist in .../my_project/mobile`.

So read the Expo Mobile PUBLISH result on this PR as the verdict on #603, not on the quoting change. If the build fails somewhere new, that is progress rather than regression, and it means the archive fix worked and something further along needs attention.

Verified on the rendered RN template: `lint:tslint` and `lint:eslint` pass, and `format:check` drops from three files to the two Jinja ones.