### PR TITLE
Let the staging build fire on main

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -50,22 +50,14 @@ jobs:
         with:
           fetch-depth: 5
         name: check diff
-      # No `workflow_dispatch` branch here. `Setup` runs only on a successful
-      # deployment_status, and this job needs `Setup`, so a manual run never
-      # reaches this step.
-      - id: checkdiff
-        run: |
-          git fetch origin main
-          # `tr` strips the padding `wc -l` adds; the `publish` job compares
-          # this output against 0.
-          changed=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
-          echo "Mobile files changed: $changed"
-          echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
       # A review app's URL carries `pr-<number>`; a staging deployment's does
       # not. The `publish` job builds `review_<number>` for the first and the
-      # `staging` profile for the second. Before this output existed, a
-      # staging deployment produced the profile name `review_`, which does
-      # not exist, and `eas build` errored.
+      # `staging` profile for the second, and `checkdiff` below needs to know
+      # which one it is, so this step comes first.
+      #
+      # No `workflow_dispatch` branch here. `Setup` runs only on a successful
+      # deployment_status, and this job needs `Setup`, so a manual run never
+      # reaches these steps.
       - id: prnumber
         run: |
           pr_number=$(echo "$ENVIRONMENT_URL" | grep -oP '(?<=pr-)\d+' || true)
@@ -73,6 +65,27 @@ jobs:
           echo "PR_NUMBER=$pr_number" >> $GITHUB_OUTPUT
         env:
           ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
+      - id: checkdiff
+        run: |
+          git fetch origin main
+          # A review app's commit sits ahead of main, so main is the base that
+          # answers "what does this pull request change". A staging
+          # deployment's commit IS main, which makes that same diff empty
+          # every time and stops the job from ever building; there the base is
+          # the commit before it.
+          if [ -n "$PR_NUMBER" ]; then
+            base="origin/main"
+          else
+            base="HEAD~1"
+          fi
+          # `tr` strips the padding `wc -l` adds; the `publish` job compares
+          # this output against 0.
+          changed=$(git diff --name-only "$base" HEAD -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
+          echo "Diff base: $base"
+          echo "Mobile files changed: $changed"
+          echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
+        env:
+          PR_NUMBER: ${{ steps.prnumber.outputs.PR_NUMBER }}
 
   publish:
     if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0
@@ -212,7 +225,11 @@ jobs:
         run: |
           eas build --platform ios --profile "$BUILD_PROFILE" --non-interactive
 
+      # The development client build exists so a reviewer can install a dev
+      # client for one pull request. A staging deployment has no such reader,
+      # so main builds the `staging` profile alone.
       - name: Build the app (development client BUILD)
+        if: env.PR_NUMBER != ''
         working-directory: ./my_project/mobile
         run: |
           eas build --platform ios --profile "${BUILD_PROFILE}_dc" --non-interactive


### PR DESCRIPTION
## What This Does

Makes the mobile-diff gate ask the right question on main, and builds the `staging` profile alone there.

`configuremobile` decided whether the mobile client changed with `git diff --name-only origin/main`, taken from the deployment's commit. On a review app that is right, because the commit sits ahead of main. On a staging deployment the commit **is** main, so the diff is empty every time and the job never builds. That is why the staging profile added in #601 has never run: #602 changed the mobile lock file and its staging deployment still reported `Mobile files changed: 0`. The single staging run that did happen today only got through because a deployment for an older commit raced a newer main.

The fix reads the PR number first, then picks the base from it - main for a review app, the previous commit for a staging deployment.

| Deployment | Base | #602 / #604 (mobile) | #600 / #603 (workflow only) |
|---|---|---|---|
| review app | `origin/main` | runs | skips |
| staging | `HEAD~1` | **runs** (was: never) | skips |

Main also builds `staging` alone now. The development client build exists so a reviewer can install a dev client for one pull request, and a staging deployment has no such reader. At the current rate of mobile changes - 21 merges in six months, almost all dependency patches - that puts this near three or four iOS builds a month.

## Note for reviewers

**The review path must come out unchanged, and that is the thing to check.** I verified it rather than assumed it: for three real commits, checked out in a worktree the way CI checks them out, the old expression and the new one return the same count. `git diff A --` and `git diff A HEAD` differ only when the working tree is dirty, which a CI checkout never is.

**Why this is worth spending build minutes on.** The break we spent this afternoon on started on 2 September and survived a week. Pull request builds are the usual detector and they do work - #602 caught it - but a pull request merged before its Heroku review app finishes deploying never builds at all. #599 touched the mobile lock file and has no Expo run in the record for exactly that reason. A gate that fires on merge closes that hole regardless of how fast the pull request was merged.

**This PR cannot test itself either.** It touches only the workflow, so both its own review app and the staging deployment for its merge will skip. The first real staging build lands on the next merge that touches `clients/mobile/react-native/`, and it will be the first time that profile has ever built. Its one previous attempt errored in August, which the `.gitignore` cause in #603 probably explains, but "probably" is doing work in that sentence.