### PR TITLE
Make the mobile template render prettier-clean

### DIFF
--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/components/date-picker-modal.tsx
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/components/date-picker-modal.tsx
@@ -34,7 +34,7 @@ export const DatePickerModal: React.FC<Props> = ({
       <View className="flex-1 justify-center items-center bg-white/40">
         <View className="bg-white rounded-xl p-4 w-[90%] max-w-[400px] shadow-lg shadow-black/20 border border-gray-100">
           <Text className="text-lg text-black font-semibold mb-4 text-center">{title}</Text>
-          {% raw %}
+{% raw %}
           <Calendar
             onDayPress={(day: DateData) => {
               setTempDate(parseDateLocal(day.dateString))
@@ -42,15 +42,15 @@ export const DatePickerModal: React.FC<Props> = ({
             markedDates={{
               [selected]: {
                 selected: true,
-                selectedColor: "#F68F58",
+                selectedColor: '#F68F58',
               },
             }}
             minDate={formattedMinDate}
             maxDate={formattedMaxDate}
             theme={{
-              todayTextColor: "#F68F58",
+              todayTextColor: '#F68F58',
               selectedDayTextColor: '#ffffff',
-              selectedDayBackgroundColor: "#F68F58",
+              selectedDayBackgroundColor: '#F68F58',
               arrowColor: '#2563EB',
               monthTextColor: '#111827',
               textDayFontWeight: '500',
@@ -58,8 +58,8 @@ export const DatePickerModal: React.FC<Props> = ({
               textDayFontSize: 16,
               textMonthFontSize: 18,
             }}
-            />
-            {% endraw %}
+          />
+{% endraw %}
           <View className="flex-row justify-end mt-4 gap-4">
             <Pressable onPress={onClose}>
               <Text className="text-alert font-medium">Cancel</Text>

--- a/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/screens/routes.tsx
+++ b/{{cookiecutter.project_slug}}/clients/mobile/react-native/src/screens/routes.tsx
@@ -129,7 +129,6 @@ const RootNavigator = () => (
   </RootStack.Navigator>
 )
 {% endraw %}
-
 // App Root Component with navigation ref
 export const AppRoot = () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## What This Does

Takes `npm run format:check` on the mobile client from three failing files to none.

Two of those files hold Jinja `{% raw %}` blocks, which is why prettier reported a parse error on them rather than a warning: it cannot read the template form at all. The rendered form is plain TypeScript, so the fix belongs in how the markers sit, not in prettier.

A marker on its own line renders as an empty line. An indented marker therefore leaves its indent behind as trailing whitespace, and a blank line next to one makes two. So both markers in `date-picker-modal.tsx` move to column 0, and the blank line after `{% endraw %}` in `routes.tsx` goes.

That exposed two real defects sitting inside the raw block, where prettier could never reach them: the `Calendar` self-closing tag was indented two columns deeper than its own element, and three colors used double quotes where the project's config asks for single.

Verified on the rendered RN template: `format:check` passes across `src/`, and `lint:tslint` and `lint:eslint` still pass. The raw blocks still do their job - the rendered files keep all six `{{` JSX braces and carry no Jinja residue.

## Note for reviewers

**This is also the trigger that finally tests the staging build, and that is the more interesting half.** It touches `clients/mobile/react-native/`, so once it merges the staging deployment's diff against the previous commit reports a change and `eas build --profile staging` runs. That profile has never built successfully: its one attempt, in August, errored under the `.gitignore` cause that #603 fixed. So this merge is the first real test of both #605's gate and the `staging` profile.

Watch the Expo Mobile PUBLISH run on **main** after this merges, not the run on this pull request. The run here exercises the review path, which already works.

Being plain about the ordering: I earlier called these two files not worth fixing, on the grounds that formatting them meant rendering and putting the markers back by hand. That was wrong. The markers did not need moving through a render at all, only unindenting.