### PR TITLE
Render the mobile client on a staging deployment

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -12,6 +12,10 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # `get_client_config.sh` compares against HEAD~1 on a staging
+          # deployment, which the default depth of 1 does not reach.
+          fetch-depth: 5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -32,6 +36,8 @@ jobs:
           config_file=$(./scripts/get_client_config.sh)
           uv run cookiecutter . --config-file $config_file --no-input -f
           cat $config_file
+        env:
+          ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
       - uses: actions/upload-artifact@v4
         with:
           name: my_project
@@ -68,16 +74,10 @@ jobs:
       - id: checkdiff
         run: |
           git fetch origin main
-          # A review app's commit sits ahead of main, so main is the base that
-          # answers "what does this pull request change". A staging
-          # deployment's commit IS main, which makes that same diff empty
-          # every time and stops the job from ever building; there the base is
-          # the commit before it.
-          if [ -n "$PR_NUMBER" ]; then
-            base="origin/main"
-          else
-            base="HEAD~1"
-          fi
+          # The same script `get_client_config.sh` uses, so the job that
+          # renders the template and the job that decides to build it cannot
+          # disagree about what changed.
+          base=$(./scripts/mobile_diff_base.sh)
           # `tr` strips the padding `wc -l` adds; the `publish` job compares
           # this output against 0.
           changed=$(git diff --name-only "$base" HEAD -- | grep "/clients/mobile/react-native/" | wc -l | tr -d '[:space:]')
@@ -85,7 +85,7 @@ jobs:
           echo "Mobile files changed: $changed"
           echo "BUILD_MOBILE_APP=$changed" >> $GITHUB_OUTPUT
         env:
-          PR_NUMBER: ${{ steps.prnumber.outputs.PR_NUMBER }}
+          ENVIRONMENT_URL: ${{ github.event.deployment_status.environment_url }}
 
   publish:
     if: needs.configuremobile.outputs.BUILD_MOBILE_APP != 0

--- a/scripts/get_client_config.sh
+++ b/scripts/get_client_config.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 git fetch origin main
-react_count=$(git diff --name-only origin/main -- | grep "/clients/web/react/" | wc -l)
-rn_count=$(git diff --name-only origin/main -- | grep "/clients/mobile/react-native/" | wc -l)
+base=$(./scripts/mobile_diff_base.sh)
+react_count=$(git diff --name-only "$base" HEAD -- | grep "/clients/web/react/" | wc -l)
+rn_count=$(git diff --name-only "$base" HEAD -- | grep "/clients/mobile/react-native/" | wc -l)
 config_file_path="cookiecutter/react_template.yaml"
 
 if [ "$rn_count" != 0 ]; then

--- a/scripts/mobile_diff_base.sh
+++ b/scripts/mobile_diff_base.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Prints the git ref to compare against when deciding whether a client
+# directory changed in the commit a deployment was made from.
+#
+# A review app's URL carries `pr-<number>`, and its commit sits ahead of main,
+# so main answers "what does this pull request change". A staging deployment's
+# commit IS main, which makes that same comparison empty every time; there the
+# question is what the merge itself brought in, so the base is the commit
+# before it.
+#
+# Both `get_client_config.sh` and the `configuremobile` job read this, so the
+# two stay in step. They disagreed once, and the mobile app was then left out
+# of the render while the build was still asked for.
+
+if echo "${ENVIRONMENT_URL:-}" | grep -qE 'pr-[0-9]+'; then
+  echo "origin/main"
+else
+  echo "HEAD~1"
+fi


### PR DESCRIPTION
## What This Does

Fixes the first staging build, which never reached EAS. It failed in `Create config files` with:

```
cp: cannot create regular file 'my_project/resources/app.config.vars.txt': No such file or directory
```

The render held no mobile app to configure. #605 fixed the base that `configuremobile` compares against, but `scripts/get_client_config.sh` decides *what the template renders*, and it carried the same fault - it also compared against `origin/main`, which is empty on main, so it left `include_mobile` at `"n"` and skipped the `resources/` copy. One job then asked for a build of something the other had not rendered.

That is the actual lesson here: two places answered "did the mobile client change?" and I fixed only one. So the rule now lives in `scripts/mobile_diff_base.sh` and both callers read it, rather than being written out twice.

`Setup` also needs `fetch-depth: 5`, because it now reaches `HEAD~1` and the default depth of 1 does not, plus the deployment URL that picks the base.

Checked against real commits: a staging deployment for #602 or #606 reports the mobile change and renders with `include_mobile: "y"`, while one for #603 or #605, which touched only the workflow, still reports none. Rendering `e3a6b81b` as a staging deployment produces `my_project/mobile` and `my_project/resources`, including the exact file the failing step could not find.

## Note for reviewers

**This PR cannot trigger a staging build either, because it touches no mobile file.** The next merge that touches `clients/mobile/react-native/` will be the real test, and it will be the first time `eas build --profile staging` has run.

Worth knowing about `get_client_config.sh` generally: it mutates tracked files in the workspace, `sed -i.bak` on `cookiecutter/react_template.yaml` and a `cp -r resources/` into the template directory. That is surprising for something whose name suggests it only reads, and it is why the script has to be run from the repository root. I left the behavior alone here, but it would repay a look on its own.