### PR TITLE
feat: add `just debug` overlay for VSCode debugger attach in Traefik mode

### DIFF
--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -65,6 +65,32 @@ This creates the `proxy` Docker network, generates `~/traefik/docker-compose.yml
 
 **To switch back to standalone mode:** Stop Traefik (`docker stop traefik`) and run `just up`. It falls back to port bindings automatically.
 
+### Debugging with VSCode
+
+The server runs under [`debugpy`](https://github.com/microsoft/debugpy), listening on port `5678`. Attach a debugger to set breakpoints in the running container.
+
+```bash
+just debug
+```
+
+`just debug` is a drop-in replacement for `just up` that also publishes the debugpy port to the host. It's needed because Traefik can only route HTTP(S), not the plaintext DAP protocol debugpy speaks — so in Traefik mode the port has to be published directly. In standalone mode `docker-compose.override.yml` already publishes it, but `just debug` works there too.
+
+Then add a debugpy **attach** config to `.vscode/launch.json` and start it:
+
+```json
+{
+  "name": "Python: Attach to Docker",
+  "type": "debugpy",
+  "request": "attach",
+  "connect": { "host": "localhost", "port": 5678 },
+  "pathMappings": [{ "localRoot": "${workspaceFolder}", "remoteRoot": "/app" }]
+}
+```
+
+The debug ports are fixed, so only **one project at a time** can hold them — debug one project, run the rest with `just up`.
+
+**Adding more debug targets:** to debug another process (e.g. a `process_tasks` background worker), give it its own debugpy port in `compose/docker-compose.debug.yml` and a matching attach config. See the comments in that file for a worked example.
+
 ### Worktree Workflow
 
 Work on multiple branches simultaneously with fully isolated Docker stacks:

--- a/{{cookiecutter.project_slug}}/compose/docker-compose.debug.yml
+++ b/{{cookiecutter.project_slug}}/compose/docker-compose.debug.yml
@@ -1,0 +1,32 @@
+# Opt-in debug overlay — layered only by `just debug`.
+# Publishes debugpy's raw DAP port directly to the host, because Traefik can only
+# host-route TCP with TLS+SNI and debugpy speaks plaintext TCP. In standalone
+# (override.yml) mode the port is already published; this overlay is what makes
+# attaching work in Traefik mode.
+#
+# Fixed host ports => only ONE project can publish them at a time. That's fine:
+# you attach a debugger to one project at a time. Other projects use plain `just up`.
+#
+# The port must be published on the SAME service whose container runs that debugpy
+# listener. The server's entrypoint (compose/server/start) already launches:
+#   python -m debugpy --listen 0.0.0.0:5678 server/manage.py runserver ...
+# so 5678 is published on `server` below. Attach in VSCode with a debugpy "attach"
+# config pointing at localhost:5678.
+#
+# --- Adding another debug target ---
+# To debug a second process (e.g. a background_task worker), give it its own port:
+#   1. Add a service here that runs the process under debugpy on a new port, and
+#      publish that port on the same service. Example:
+#
+#        worker:
+#          command: python -m debugpy --listen 0.0.0.0:5679 server/manage.py process_tasks
+#          ports:
+#            - "5679:5679"
+#
+#   2. Add a matching debugpy "attach" config in .vscode/launch.json → localhost:5679.
+#
+# Each debugpy listener needs its own port; two listeners cannot share 5678.
+services:
+  server:
+    ports:
+      - "5678:5678"

--- a/{{cookiecutter.project_slug}}/justfile
+++ b/{{cookiecutter.project_slug}}/justfile
@@ -148,6 +148,26 @@ up:
     fi
     echo "Application is starting (PROJECT=$project)..."
 
+# Start all services with debugpy port(s) published for a VSCode attach.
+# Layers compose/docker-compose.debug.yml so the debugpy DAP port reaches the host
+# even in Traefik mode (Traefik can't proxy plaintext DAP). Only one project can
+# hold a given debug port at a time — debug one project at a time. To add more
+# debug targets (e.g. a worker), see compose/docker-compose.debug.yml.
+[group('docker')]
+debug:
+    #!/usr/bin/env bash
+    set -a; source .env; set +a
+    project=$(just _project)
+    if docker network inspect proxy >/dev/null 2>&1; then
+      just setup-traefik
+      PROJECT=$project docker compose -f docker-compose.yaml -f compose/docker-compose.traefik.yml -f compose/docker-compose.debug.yml up -d
+    else
+      # Explicit -f flags stop Compose auto-loading docker-compose.override.yml,
+      # so list it alongside the debug overlay.
+      PROJECT=$project docker compose -f docker-compose.yaml -f docker-compose.override.yml -f compose/docker-compose.debug.yml up -d
+    fi
+    echo "Application is starting with debugpy port 5678 exposed (PROJECT=$project)..."
+
 [group('docker')]
 down:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
Debugpy's port (`5678`) isn't reachable when running in Traefik mode — Traefik only host-routes HTTP(S), not the plaintext DAP protocol debugpy speaks. This adds an opt-in overlay + `just debug` recipe that publishes the port directly to the host.

Ported generically from [3leafcoder/rapa#516](https://github.com/3leafcoder/rapa/pull/516), dropping that project's rapa-specific `worker` service and `launch.json` edits.

## Changes
- **`compose/docker-compose.debug.yml`** (new) — publishes debugpy's `5678` to the host. Header comments explain *why* and give a worked example of adding another target (e.g. a `process_tasks` worker on its own port).
- **`justfile`** — new `just debug` recipe, a drop-in for `just up` that layers the overlay (handles both Traefik and standalone paths).
- **`README.md`** — new "Debugging with VSCode" section with the attach config and extension notes.

## Notes
- Standalone mode already publishes `5678` via `docker-compose.override.yml`; this overlay is what makes attach work in **Traefik** mode. `just debug` works in both.
- Debug ports are fixed → only one project at a time can hold them.

## Testing
- [ ] `just debug` in standalone mode → attach on `localhost:5678`
- [ ] `just debug` in Traefik mode → attach on `localhost:5678`
- [ ] Verify bootstrapper still generates correctly

https://claude.ai/code/session_01FRq5kVarPkTQpgw6wCDtjy