### PR TITLE
Require the current password to change a password

### DIFF
--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_password_change.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/core/tests/test_password_change.py
@@ -1,0 +1,72 @@
+"""
+Tests for the password-change endpoint.
+"""
+
+import pytest
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APIClient
+
+from {{ cookiecutter.project_slug }}.core.models import User
+
+URL = "/api/password/change/"
+CURRENT_PASSWORD = "current-password-1234"
+NEW_PASSWORD = "new-password-9876"
+
+
+@pytest.fixture
+def client_for_user(db):
+    user = User.objects.create_user(email="member@example.com", password=CURRENT_PASSWORD)
+    token, _ = Token.objects.get_or_create(user=user)
+    client = APIClient()
+    client.credentials(HTTP_AUTHORIZATION=f"Token {token.key}")
+    return client, user
+
+
+@pytest.mark.django_db
+class TestPasswordChange:
+    def test_change_requires_the_current_password(self, client_for_user):
+        """The old-password field is enforced.
+
+        dj-rest-auth reads OLD_PASSWORD_FIELD_ENABLED from the REST_AUTH dict
+        and defaults it to False. Set outside that dict it has no effect, and
+        an authenticated caller can set a new password without knowing the
+        current one.
+        """
+        client, _ = client_for_user
+
+        response = client.post(URL, {"new_password1": NEW_PASSWORD, "new_password2": NEW_PASSWORD})
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    def test_change_succeeds_with_the_current_password(self, client_for_user):
+        client, user = client_for_user
+
+        response = client.post(
+            URL,
+            {
+                "old_password": CURRENT_PASSWORD,
+                "new_password1": NEW_PASSWORD,
+                "new_password2": NEW_PASSWORD,
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        user.refresh_from_db()
+        assert user.check_password(NEW_PASSWORD)
+
+    def test_change_is_refused_with_the_wrong_current_password(self, client_for_user):
+        client, user = client_for_user
+
+        response = client.post(
+            URL,
+            {
+                "old_password": "not-the-current-password",
+                "new_password1": NEW_PASSWORD,
+                "new_password2": NEW_PASSWORD,
+            },
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        user.refresh_from_db()
+        assert user.check_password(CURRENT_PASSWORD)

--- a/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/server/{{cookiecutter.project_slug}}/settings.py
@@ -94,7 +94,13 @@ MIDDLEWARE = [
     "{{ cookiecutter.project_slug }}.common.api_errors.ApiJsonErrorMiddleware",
 ]
 
-OLD_PASSWORD_FIELD_ENABLED = True
+# dj-rest-auth 7 reads its configuration from this dict. A bare
+# OLD_PASSWORD_FIELD_ENABLED is a version 2 setting that version 7 ignores,
+# and the default is False, so the password-change endpoint would accept a new
+# password without asking for the current one.
+REST_AUTH = {
+    "OLD_PASSWORD_FIELD_ENABLED": True,
+}
 LOGIN_URL = "rest_framework:login"
 LOGOUT_URL = "rest_framework:logout"
 


### PR DESCRIPTION
## What This Does

Moves `OLD_PASSWORD_FIELD_ENABLED` into a `REST_AUTH` dict so dj-rest-auth reads it.

dj-rest-auth 7 takes its configuration from `getattr(settings, "REST_AUTH", None)`, and `OLD_PASSWORD_FIELD_ENABLED` defaults to `False`. The template set it as a bare module-level name, which version 7 ignores. `api/password/change/` is routed, so a generated project has that endpoint accepting a new password without the current one, and accepting a wrong one.

The bare form was correct for dj-rest-auth 2. The pin has been `7.0.*` for some time, so the setting has been inert since the upgrade.

Adds three tests for the endpoint: it refuses a change with no current password, refuses a wrong one, and accepts a correct one. Two of the three fail against the previous setting.

## Note for reviewers

Worth checking whether existing projects generated from this template need the same change applied, since the setting is inert wherever it was copied out as a bare name.

Verified by generating the project with `cookiecutter . --config-file cookiecutter/react_template.yaml --no-input -f` and running the new tests against it, then restoring the bare setting and confirming two of them fail.
